### PR TITLE
update readme

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,32 +1,39 @@
 gosnmp
 ======
+[![Build Status](https://travis-ci.org/soniah/gosnmp.svg?branch=master)](https://travis-ci.org/soniah/gosnmp)
+[![Coverage](http://gocover.io/_badge/github.com/soniah/gosnmp)](http://gocover.io/github.com/soniah/gosnmp)
+[![GoDoc](https://godoc.org/github.com/soniah/gosnmp?status.png)](http://godoc.org/github.com/soniah/gosnmp)
+
 
 GoSNMP is an SNMP client library written fully in Go. Currently it
-supports GetRequest, GetNext, GetBulk, and SetRequest (beta, see below).
+supports GetRequest, GetNext, GetBulk, Walk (beta, see below), and SetRequest (beta, see below).
 
 About
 -----
 
-**soniah/gosmp** is based on **alouca/gosnmp** - many thanks to Andreas
+**soniah/gosnmp** is based on **alouca/gosnmp** - many thanks to Andreas
 Louca for starting the project. Thanks also to the following who have
 contributed:
 
-* Jacob Dubinsky - all of GetNext and GetBulk
-* Jon Auer - fixes
+* Chris Dance (@codedance) - Fixes, SNMP Walk functionality and examples, Retry Support
+* Nathan Owens (@virtuallynathan) - Fixes / Changes
+* Jacob Dubinsky (@jdubinsky) - All of GetNext and GetBulk
+* Jon Auer (@jda) - Data truncation fix
+* Andreas Louca (@alouca) - Original library
 
 Overview
 --------
 
-GoSNMP has the following public functions:
+GoSNMP has the following SNMP functions:
 
 * **Get** (single or multiple OIDs)
 * **GetNext**
 * **GetBulk**
+* **Walk** - retrieves a subtree of values using GETNEXT.
+* **BulkWalk** - retrieves a subtree of values using GETBULK.
 * **Set** (beta - only supports setting one integer OID)
-* **ToBigInt** - treat returned values as `*big.Int`
-* **Partition** - facilitates dividing up large slices of OIDs
 
-**soniah/gosmp** has diverged from **alouca/gosnmp** - your existing
+**soniah/gosnmp** has diverged from **alouca/gosnmp** - your existing
 code will require slight modification:
 
 * the **Get** function has a different method signature
@@ -36,13 +43,11 @@ code will require slight modification:
   logger if it conforms to the simple interface (Print and Printf).
   Otherwise debugging will be discarded (/dev/null).
 
-GoSNMP is still under development, therefore API's may change and bugs
+gosnmp is still under development, therefore API's may change and bugs
 will be squashed. Test Driven Development is used - you can help by
 sending packet captures (see Packet Captures below). There may be more
 than one branch on github. **master** is safe to pull from, other
 branches unsafe as history may be rewritten.
-
-Sonia Hamilton, sonia@snowfrog.net, http://blog.snowfrog.net.
 
 Installation
 ------------
@@ -66,6 +71,7 @@ Usage
 
 Here is code from **example/example.go**, demonstrating how to use GoSNMP:
 
+```go
     // Default is a pointer to a GoSNMP struct that contains sensible defaults
     // eg port 161, community public, etc
     g.Default.Target = "192.168.1.10"
@@ -96,7 +102,7 @@ Here is code from **example/example.go**, demonstrating how to use GoSNMP:
             fmt.Printf("number: %d\n", g.ToBigInt(variable.Value))
         }
     }
-
+```
 Running this example gives the following output (from my printer):
 
     % go run example.go
@@ -106,6 +112,8 @@ Running this example gives the following output (from my printer):
 **example/example2.go** is similar to example.go, however is uses a custom
 &GoSNMP rather than **g.Default**.
 
+**example/walkexample.go** demonstrates using ```BulkWalk```.
+
 Bugs
 ----
 
@@ -114,13 +122,14 @@ The following BER types have been implemented:
 * 0x02 Integer
 * 0x04 OctetString
 * 0x06 ObjectIdentifier
-* 0x40 IpAddress
+* 0x40 IPAddress (IPv4 & IPv6)
 * 0x41 Counter32
 * 0x42 Gauge32
 * 0x43 TimeTicks
 * 0x46 Counter64
 * 0x80 NoSuchObject
 * 0x81 NoSuchInstance
+* 0x82 EndOfMibView
 
 The following (less common) BER types haven't been implemented, as I ran out of
 time or haven't been able to find example devices to query:
@@ -136,7 +145,7 @@ time or haven't been able to find example devices to query:
 Packet Captures
 ---------------
 
-**Please email me** at sonia@snowfrog.net with packet captures containing
+Please create an issue on GitHub with packet captures (upload them somewhere) containing
 samples of the missing BER types, or of any other bugs you find. Please include
 2 or 3 examples of the missing/faulty BER type, interspersed with a couple of
 other common BER's eg an Integer, a Counter32 ie about 6-8 OIDs.


### PR DESCRIPTION
Updated readme, may not 100% represent code, e.g.
-\* **ToBigInt** - treat returned values as `*big.Int`
 -\* **Partition** - facilitates dividing up large slices of OIDs

but those could/should be moved to helper.go? 
