### PR TITLE
Walk's max-repetitions & non-repeaters can be set

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -26,9 +26,6 @@ const (
 
 	// Java SNMP uses 50, snmp-net uses 10
 	defaultMaxRepetitions = 50
-
-	// TODO comment
-	defaultNonRepeaters = 0
 )
 
 // LoggingDisabled is set if the Logger is nil, short circuits any 'slog' calls
@@ -62,6 +59,14 @@ type GoSNMP struct {
 	// output will be discarded (/dev/null). For verbose logging to stdout:
 	// x.Logger = log.New(os.Stdout, "", 0)
 	Logger Logger
+
+	// MaxRepititions sets the GETBULK max-repetitions used by BulkWalk*
+	// (default: 50)
+	MaxRepetitions int
+
+	// NonRepeaters sets the GETBULK max-repeaters used by BulkWalk*
+	// (default: 0 as per RFC 1905)
+	NonRepeaters int
 
 	// Internal - used to sync requests to responses
 	requestID uint32

--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -29,6 +29,8 @@ func TestAPIConfigTypes(t *testing.T) {
 	g.Timeout = time.Duration(0)
 	g.Retries = 0
 	g.Logger = log.New(ioutil.Discard, "", 0)
+	g.MaxRepetitions = 0
+	g.NonRepeaters = 0
 
 	var c net.Conn
 	c = g.Conn

--- a/walk.go
+++ b/walk.go
@@ -15,11 +15,15 @@ func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) e
 	}
 	oid := rootOid
 	requests := 0
+	maxReps := x.MaxRepetitions
+	if maxReps <= 0 {
+		maxReps = defaultMaxRepetitions
+	}
 
 	getFn := func(oid string) (result *SnmpPacket, err error) {
 		switch getRequestType {
 		case GetBulkRequest:
-			return x.GetBulk([]string{oid}, defaultNonRepeaters, defaultMaxRepetitions)
+			return x.GetBulk([]string{oid}, uint8(x.NonRepeaters), uint8(maxReps))
 		case GetNextRequest:
 			return x.GetNext([]string{oid})
 		default:


### PR DESCRIPTION
- The walk function uses default values.  It's now possible to
  change/override the default values via instance variables on
  GoSNMP. Closes issue #17 on soniah/gosnmp.
