### PR TITLE
Normalize rootOid. Support for Oids with and without initial dot

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -13,6 +13,11 @@ func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) e
 	if rootOid == "" || rootOid == "." {
 		rootOid = baseOid
 	}
+
+	if !strings.HasPrefix(rootOid, ".") {
+		rootOid = string(".") + rootOid
+	}
+
 	oid := rootOid
 	requests := 0
 


### PR DESCRIPTION
In previous version the walk works for OIDs with and without initial dot, but at the current version the walk with the initial dot does not work.
This change normalize the root oid so the OID without the initial dot works again.
