### PR TITLE
removed duplicate method call

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -506,8 +506,9 @@ func unmarshalVBL(packet []byte, response *SnmpPacket,
 		if oid, ok = rawOid.([]int); !ok {
 			return nil, fmt.Errorf("unable to type assert rawOid |%v| to []int", rawOid)
 		}
+		oidStr := oidToString(oid)
 		if LoggingDisabled != true {
-			slog.Printf("OID: %s", oidToString(oid))
+			slog.Printf("OID: %s", oidStr)
 		}
 
 		// Parse Value
@@ -517,7 +518,7 @@ func unmarshalVBL(packet []byte, response *SnmpPacket,
 		}
 		valueLength, _ := parseLength(packet[cursor:])
 		cursor += valueLength
-		response.Variables = append(response.Variables, SnmpPDU{oidToString(oid), v.Type, v.Value})
+		response.Variables = append(response.Variables, SnmpPDU{oidStr, v.Type, v.Value})
 	}
 	return response, nil
 }


### PR DESCRIPTION
This is a minor change just to increase performance. Since the oidToString takes some time to execute it is unnecessary to do multiple calls to the function.
