### PR TITLE
Fixed walk issue (TestGenericWalk)

### DIFF
--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -95,7 +95,6 @@ func TestGenericGetNext(t *testing.T) {
 	}
 }
 
-/*
 func TestGenericWalk(t *testing.T) {
 	setupConnection(t)
 	defer Default.Conn.Close()
@@ -108,7 +107,6 @@ func TestGenericWalk(t *testing.T) {
 		t.Fatalf("Expected multiple values, got %d", len(result))
 	}
 }
-*/
 
 func TestGenericBulkWalk(t *testing.T) {
 	setupConnection(t)

--- a/walk.go
+++ b/walk.go
@@ -49,20 +49,20 @@ RequestLoop:
 		}
 
 		for _, v := range response.Variables {
-			if v.Name == oid {
-				return fmt.Errorf("OID not increasing: %s", v.Name)
+			if v.Type == EndOfMibView || v.Type == NoSuchObject || v.Type == NoSuchInstance {
+				x.Logger.Printf("BulkWalk terminated with type 0x%x", v.Type)
+				break RequestLoop
 			}
 			if !strings.HasPrefix(v.Name, rootOid) {
 				// Not in the requested root range.
 				break RequestLoop
 			}
+			if v.Name == oid {
+				return fmt.Errorf("OID not increasing: %s", v.Name)
+			}
 			// Report our pdu
 			if err := walkFn(v); err != nil {
 				return err
-			}
-			if v.Type == EndOfMibView || v.Type == NoSuchObject || v.Type == NoSuchInstance {
-				x.Logger.Printf("BulkWalk terminated with type 0x%x", v.Type)
-				break RequestLoop
 			}
 		}
 		// Save last oid for next request


### PR DESCRIPTION
The test TestGenericWalk was failing against snmpd on Ubuntu.  This was
caused by the last OID repeating with an EndOfMibView.  Reordered the
walk loop checks so the sanity checks are done after testing for
EndOfMibView.
