### PR TITLE
optimise oidToString function to perform better

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -371,11 +371,15 @@ func marshalOID(oid string) ([]byte, error) {
 }
 
 func oidToString(oid []int) (ret string) {
-	values := make([]interface{}, len(oid))
-	for i, v := range oid {
-		values[i] = v
+	oidAsString := make([]string, len(oid)+1)
+
+	// used for appending of the first dot
+	oidAsString[0] = ""
+	for i, _ := range oid {
+		oidAsString[i+1] = strconv.Itoa(oid[i])
 	}
-	return fmt.Sprintf(strings.Repeat(".%d", len(oid)), values...)
+
+	return strings.Join(oidAsString, ".")
 }
 
 // parseBase128Int parses a base-128 encoded int from the given offset in the

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,32 @@
+package gosnmp
+
+import (
+	"testing"
+)
+
+func TestOidToString(t *testing.T) {
+	oid := []int{1, 2, 3, 4, 5}
+	expected := ".1.2.3.4.5"
+	result := oidToString(oid)
+
+	if result != expected {
+		t.Errorf("oidToString(%v) = %s, want %s", oid, result, expected)
+	}
+}
+
+func TestWithAnotherOid(t *testing.T) {
+	oid := []int{4, 3, 2, 1, 3}
+	expected := ".4.3.2.1.3"
+	result := oidToString(oid)
+
+	if result != expected {
+		t.Errorf("oidToString(%v) = %s, want %s", oid, result, expected)
+	}
+}
+
+func BenchmarkOidToString(b *testing.B) {
+	oid := []int{1, 2, 3, 4, 5}
+	for i := 0; i < b.N; i++ {
+		oidToString(oid)
+	}
+}


### PR DESCRIPTION
Adds an optimisation to oidToString function to perform better.

Before Optimisation:
BenchmarkOidToString     1000000          1077 ns/op

After Optimisation:
BenchmarkOidToString     5000000           665 ns/op
