### PR TITLE
Bugfix Lenght Octets bytes in reverse order (not X.690 compliant)

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -335,8 +335,18 @@ func marshalLength(length int) ([]byte, error) {
 	}
 	bufBytes = bufBytes[0 : len(bufBytes)-1] // remove trailing 00
 
+	var reverseBufBytes []byte
+	reverseBufBytes = make([]byte, len(bufBytes), len(bufBytes))
+	reverseIndex := len(bufBytes) - 1
+	positiveIndex := 0
+	for reverseIndex >= 0 {
+		reverseBufBytes[positiveIndex] = bufBytes[reverseIndex]
+		reverseIndex--
+		positiveIndex++
+	}
+
 	header := []byte{byte(128 | len(bufBytes))}
-	return append(header, bufBytes...), nil
+	return append(header, reverseBufBytes...), nil
 }
 
 func marshalObjectIdentifier(oid []int) (ret []byte, err error) {

--- a/misc_test.go
+++ b/misc_test.go
@@ -22,6 +22,8 @@ var testsMarshalLength = []struct {
 }{
 	{1, []byte{0x01}},
 	{129, []byte{0x81, 0x81}},
+	{272, []byte{0x82, 0x01, 0x10}},
+	{435, []byte{0x82, 0x01, 0xb3}},
 }
 
 func TestMarshalLength(t *testing.T) {


### PR DESCRIPTION
When the lenght to marshall was greater than 256 the order or the bytes was incorrent.
Acording to http://en.wikipedia.org/wiki/X.690#Length_Octets:

435 should be codified as 0x82(0b10000010), 0x01(0b00000001), 0xb3(0b10110011)
But the function return 0x82, 0xb3, 0x01
So when we only need one byte for the lengths it works great, but for longer pdus, it generate a invalid snmp datagram

I am new to golang programming so the reverse of the array is not very idiomatic, but it works :-)
