### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Bugs
 ----
 
 Rane's document [SNMP: Simple? Network Management
-Protocol](http://www.rane.com/note161.html) was useful when learning the SNMP
+Protocol](https://www.ranecommercial.com/legacy/note161.html) was useful when learning the SNMP
 protocol.
 
 Please create an [issue](https://github.com/soniah/gosnmp/issues) on


### PR DESCRIPTION
The link to the Rane document "SNMP: Simple? Network Management Protocol" explaining protocol was broken - seems Rane updated their website.

(And I'm not just trying to get a hacktoberfest t-shirt - I use gosnmp through telegraf)