### PR TITLE
Release v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.28.0
+
+This release updates the Go import path from `github.com/soniah/gosnmp`
+to `github.com/gosnmp/gosnmp`.
+
+* [CHANGE] Update project path #257
+* [ENHANCEMENT] Improve SNMPv3 trap support #253
+
 ## v1.27.0
 
 * fix a race condition - logger


### PR DESCRIPTION
This release updates the Go import path from `github.com/soniah/gosnmp`
to `github.com/gosnmp/gosnmp`.

* [CHANGE] Update project path #257
* [ENHANCEMENT] Improve SNMPv3 trap support #253

Signed-off-by: Ben Kochie <superq@gmail.com>