### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ for i, variable := range result.Variables {
     // interface{}. You could do a type switch...
     switch variable.Type {
     case g.OctetString:
-        bytes := variable.Value.([]byte)
-        fmt.Printf("string: %s\n", string(bytes))
+        // Earlier versions (<=1.26.0) return []byte value.
+        // Recent versions (>=1.27.0) return string value.
+        fmt.Printf("string: %s\n", variable.Value)
     default:
         // ... or often you're just interested in numeric values.
         // ToBigInt() will return the Value as a BigInt, for plugging


### PR DESCRIPTION
The returned value for snmp.Get when the type is OctetString is string if you use gonmp module (version >= v.1.27.0).
In previous versions this was []byte. The example in the README still uses the old behaviour.