### PR TITLE
Return OctetString as []byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* [CHANGE] Return OctetString as []byte #264
+
 ## v1.28.0
 
 This release updates the Go import path from `github.com/soniah/gosnmp`

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -124,9 +124,8 @@ func TestGenericBasicGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -145,9 +144,8 @@ func TestGenericBasicGetIPv4Only(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -342,9 +340,8 @@ func TestSnmpV3NoAuthNoPrivBasicGet(t *testing.T) {
 	if len(result.Variables) != 1 {
 		t.Fatalf("Expected result of size 1")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Logf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -370,9 +367,8 @@ func TestSnmpV3AuthMD5NoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -402,9 +398,8 @@ func TestSnmpV3AuthMD5PrivAES256CGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -430,9 +425,8 @@ func TestSnmpV3AuthSHANoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -462,9 +456,8 @@ func TestSnmpV3AuthSHAPrivAESGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -494,9 +487,8 @@ func TestSnmpV3AuthSHAPrivAES256CGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -522,9 +514,8 @@ func TestSnmpV3AuthSHA224NoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -550,9 +541,8 @@ func TestSnmpV3AuthSHA256NoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -578,9 +568,8 @@ func TestSnmpV3AuthSHA384NoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -606,9 +595,8 @@ func TestSnmpV3AuthSHA512NoPrivGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -637,9 +625,8 @@ func TestSnmpV3AuthSHA512PrivAES192Get(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -670,9 +657,8 @@ func TestSnmpV3AuthSHA512PrivAES192CGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -703,9 +689,8 @@ func TestSnmpV3AuthSHA512PrivAES256CGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -737,9 +722,8 @@ func TestSnmpV3AuthMD5PrivDESGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -770,9 +754,8 @@ func TestSnmpV3AuthSHAPrivDESGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }
@@ -804,9 +787,8 @@ func TestSnmpV3AuthMD5PrivAESGet(t *testing.T) {
 	if result.Variables[0].Type != OctetString {
 		t.Fatalf("Expected sysDescr to be OctetString")
 	}
-	if sysDescr, ok := result.Variables[0].Value.(string); !ok {
-		t.Fatalf("Couldn't assert Value to string (is %T)", result.Variables[0].Value)
-	} else if len(sysDescr) == 0 {
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
 		t.Fatalf("Got a zero length sysDescr")
 	}
 }

--- a/helper.go
+++ b/helper.go
@@ -100,7 +100,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (*variable, error) {
 		}
 
 		retVal.Type = OctetString
-		retVal.Value = string(data[cursor:length])
+		retVal.Value = data[cursor:length]
 	case Null:
 		// 0x05
 		x.logPrint("decodeValue: type is Null")

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -150,7 +150,7 @@ var testsEnmarshal = []testsEnmarshalT{
 		0x32, // finish
 		[]testsEnmarshalVarbindPosition{
 			{".1.3.6.1.4.1.2863.205.1.1.75.1.0",
-				0x1e, 0x32, OctetString, "\x80"},
+				0x1e, 0x32, OctetString, []byte{0x80}},
 		},
 	},
 	{
@@ -166,7 +166,7 @@ var testsEnmarshal = []testsEnmarshalT{
 		0x37, // finish
 		[]testsEnmarshalVarbindPosition{
 			{".1.3.6.1.4.1.2863.205.1.1.75.2.0",
-				0x1e, 0x36, OctetString, "telnet"},
+				0x1e, 0x36, OctetString, []byte("telnet")},
 		},
 	},
 	// MrSpock Set stuff
@@ -397,7 +397,7 @@ var testsUnmarshal = []struct {
 				{
 					Name:  ".1.3.6.1.2.1.1.4.0",
 					Type:  OctetString,
-					Value: "Administrator",
+					Value: []byte("Administrator"),
 				},
 				{
 					Name:  ".1.3.6.1.2.1.43.5.1.1.15.1",
@@ -412,7 +412,7 @@ var testsUnmarshal = []struct {
 				{
 					Name:  ".1.3.6.1.4.1.23.2.5.1.1.1.4.2",
 					Type:  OctetString,
-					Value: "\x00\x15\x99\x37\x76\x2b",
+					Value: []byte{0x00, 0x15, 0x99, 0x37, 0x76, 0x2b},
 				},
 				{
 					Name:  ".1.3.6.1.2.1.1.3.0",
@@ -439,7 +439,7 @@ var testsUnmarshal = []struct {
 				{
 					Name:  ".1.3.6.1.2.1.2.2.1.2.6",
 					Type:  OctetString,
-					Value: "GigabitEthernet0",
+					Value: []byte("GigabitEthernet0"),
 				},
 				{
 					Name:  ".1.3.6.1.2.1.2.2.1.5.3",
@@ -459,7 +459,7 @@ var testsUnmarshal = []struct {
 				{
 					Name:  ".1.3.6.1.2.1.3.1.1.2.10.1.10.11.0.17",
 					Type:  OctetString,
-					Value: "\x00\x07\x7d\x4d\x09\x00",
+					Value: []byte{0x00, 0x07, 0x7d, 0x4d, 0x09, 0x00},
 				},
 				{
 					Name:  ".1.3.6.1.2.1.3.1.1.3.10.1.10.11.0.2",
@@ -540,7 +540,7 @@ var testsUnmarshal = []struct {
 				{
 					Name:  ".1.3.6.1.2.1.1.9.1.3.3",
 					Type:  OctetString,
-					Value: "The MIB module for managing IP and ICMP implementations",
+					Value: []byte("The MIB module for managing IP and ICMP implementations"),
 				},
 				{
 					Name:  ".1.3.6.1.2.1.1.9.1.4.2",
@@ -772,7 +772,7 @@ func TestUnmarshal(t *testing.T) {
 							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
 						}
 					case OctetString:
-						if vb.Value.(string) != vbr.Value.(string) {
+						if !bytes.Equal(vb.Value.([]byte), vbr.Value.([]byte)) {
 							t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
 						}
 					case IPAddress, ObjectIdentifier:

--- a/trap_test.go
+++ b/trap_test.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"os" //"io/ioutil"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -127,7 +128,7 @@ func makeTestTrapHandler(t *testing.T, done chan int, version SnmpVersion) func(
 		for _, v := range packet.Variables {
 			switch v.Type {
 			case OctetString:
-				b := v.Value.(string)
+				b := v.Value.([]byte)
 				// log.Printf("OID: %s, string: %x\n", v.Name, b)
 
 				// Only one OctetString in the payload, so it must be the expected one
@@ -294,7 +295,7 @@ func TestSendInformBasic(t *testing.T) {
 
 	for i, tv := range trap.Variables {
 		rv := resp.Variables[i+1]
-		if tv != rv {
+		if reflect.DeepEqual(tv, rv) {
 			t.Fatalf("Expected variable %d = %#v, got %#v", i, tv, rv)
 		}
 	}


### PR DESCRIPTION
Since we don't know the encoding of OctetString, return as a raw []byte
rather than a string.

Reverts commit 3336f959f5694e60191e2378cda0c47e68d01211

Signed-off-by: Ben Kochie <superq@gmail.com>