### PR TITLE
Work around devices responding from different addr

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -97,6 +97,12 @@ type GoSNMP struct {
 	// (default: 0 as per RFC 1905)
 	NonRepeaters int
 
+	// UseUnconnectedUDPSocket if set, changes net.Conn to be unconnected UDP socket.
+	// Some multi-homed network gear isn't smart enough to send SNMP responses
+	// from the address it received the requests on. To work around that,
+	// we open unconnected UDP socket and use sendto/recvfrom.
+	UseUnconnectedUDPSocket bool
+
 	// netsnmp has '-C APPOPTS - set various application specific behaviours'
 	//
 	// - 'c: do not check returned OIDs are increasing' - use AppOpts = map[string]interface{"c":true} with
@@ -127,6 +133,9 @@ type GoSNMP struct {
 
 	// Internal - used to sync requests to responses - snmpv3
 	msgID uint32
+
+	// Internal - we use to send packets if using unconnected socket.
+	uaddr *net.UDPAddr
 }
 
 // Default connection settings
@@ -281,6 +290,26 @@ func (x *GoSNMP) connect(networkSuffix string) error {
 func (x *GoSNMP) netConnect() error {
 	var err error
 	addr := net.JoinHostPort(x.Target, strconv.Itoa(int(x.Port)))
+
+	switch transport := x.Transport; transport {
+	case "udp", "udp4", "udp6":
+		if x.UseUnconnectedUDPSocket {
+			x.uaddr, err = net.ResolveUDPAddr(transport, addr)
+			if err != nil {
+				return err
+			}
+
+			// As far as I know, this should not be needed in production but only to
+			// work around tests: in tests we are opening fake destination with ends up
+			// being ipv4:0.0.0.0. You can't send packets from :: to 0.0.0.0.
+			if addr4 := x.uaddr.IP.To4(); addr4 != nil {
+				x.uaddr.IP = addr4
+				transport = "udp4"
+			}
+			x.Conn, err = net.ListenUDP(transport, nil)
+			return err
+		}
+	}
 	dialer := net.Dialer{Timeout: x.Timeout}
 	x.Conn, err = dialer.DialContext(x.Context, x.Transport, addr)
 	return err

--- a/marshal.go
+++ b/marshal.go
@@ -204,7 +204,12 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 		}
 
 		x.logPrintf("SENDING PACKET: %#+v", *packetOut)
-		_, err = x.Conn.Write(outBuf)
+		// If using UDP and unconnected socket, send packet directly to stored address.
+		if uconn, ok := x.Conn.(net.PacketConn); ok && x.uaddr != nil {
+			_, err = uconn.WriteTo(outBuf, x.uaddr)
+		} else {
+			_, err = x.Conn.Write(outBuf)
+		}
 		if err != nil {
 			continue
 		}
@@ -1147,7 +1152,15 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 
 // receive response from network and read into a byte array
 func (x *GoSNMP) receive() ([]byte, error) {
-	n, err := x.Conn.Read(x.rxBuf[:])
+	var n int
+	var err error
+	// If we are using UDP and unconnected socket, read the packet and
+	// disregard the source address.
+	if uconn, ok := x.Conn.(net.PacketConn); ok {
+		n, _, err = uconn.ReadFrom(x.rxBuf[:])
+	} else {
+		n, err = x.Conn.Read(x.rxBuf[:])
+	}
 	if err == io.EOF {
 		return nil, err
 	} else if err != nil {


### PR DESCRIPTION
Some of the multihomed network devices are not smart enough:

1. You can't set a routable loopback on them
2. You can't designate the snmp response address
3. You can't tell them to sent the packet from the address they received it from

As the result, if you use connected socket, responses can't reach it.

Fortunately the workaround is very simple. I also haven't found any downside of using
it with devices that operate correctly.