### PR TITLE
README.md Update documentation link to use go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ go get github.com/gosnmp/gosnmp
 
 # Documentation
 
-http://godoc.org/github.com/gosnmp/gosnmp
+https://pkg.go.dev/github.com/gosnmp/gosnmp
 
 # Usage
 
@@ -268,5 +268,5 @@ license.
 
 See the LICENSE file for more details.
 
-The remaining code is Copyright 2012-2020 the GoSNMP Authors - see
+The remaining code is Copyright 2012 the GoSNMP Authors - see
 AUTHORS.md for a list of authors.


### PR DESCRIPTION
* Update [Documentation](https://github.com/gosnmp/gosnmp#documentation) link to use pkg.go.dev as godoc.org links will be [redirected](https://blog.golang.org/godoc.org-redirect) soon.

* Bump year in README [license](https://github.com/gosnmp/gosnmp#license)

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>