### PR TITLE
return error when GETBULK is used in v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ gosnmp
 
 GoSNMP is an SNMP client library fully written in Go. It provides Get,
 GetNext, GetBulk, Walk, BulkWalk, Set and Traps. It supports IPv4 and
-IPv6, using __SNMPv2c__ or __SNMPv3__. Builds are tested against
+IPv6, using __SNMPv1__, __SNMPv2c__ or __SNMPv3__. Builds are tested against
 linux/amd64 and linux/386.
 
 # About
@@ -26,9 +26,10 @@ GoSNMP has the following SNMP functions:
 
 * **Get** (single or multiple OIDs)
 * **GetNext**
-* **GetBulk**
+* **GetBulk** (SNMPv2c and SNMPv3 only)
 * **Walk** - retrieves a subtree of values using GETNEXT.
-* **BulkWalk** - retrieves a subtree of values using GETBULK.
+* **BulkWalk** - retrieves a subtree of values using GETBULK (SNMPv2c and
+  SNMPv3 only).
 * **Set** - supports Integers and OctetStrings.
 * **SendTrap** - send SNMP TRAPs.
 * **Listen** - act as an NMS for receiving TRAPs.

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -67,6 +67,21 @@ func setupConnection(t *testing.T) {
 	}
 }
 
+func setupConnectionInstance(gs *GoSNMP, t *testing.T) {
+	target, port := getTarget(t)
+
+	gs.Target = target
+	gs.Port = port
+
+	err := gs.Connect()
+	if err != nil {
+		if len(target) > 0 {
+			t.Fatalf("Connection failed. Is snmpd reachable on %s:%d?\n(err: %v)",
+				target, port, err)
+		}
+	}
+}
+
 func setupConnectionIPv4(t *testing.T) {
 	target, port := getTarget(t)
 
@@ -234,6 +249,20 @@ func TestGenericBulkWalk(t *testing.T) {
 	}
 	if len(result) <= 1 {
 		t.Fatalf("Expected multiple values, got %d", len(result))
+	}
+}
+
+func TestV1BulkWalkError(t *testing.T) {
+	g := &GoSNMP{
+		Version: Version1,
+	}
+	setupConnectionInstance(g, t)
+
+	g.Conn.Close()
+
+	_, err := g.BulkWalkAll("")
+	if err == nil {
+		t.Fatalf("BulkWalkAll() should fail in SNMPv1 but returned nil")
 	}
 }
 

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -450,6 +450,9 @@ func (x *GoSNMP) GetNext(oids []string) (result *SnmpPacket, err error) {
 //
 // For maxRepetitions greater than 255, use BulkWalk() or BulkWalkAll()
 func (x *GoSNMP) GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint8) (result *SnmpPacket, err error) {
+	if x.Version == Version1 {
+		return nil, fmt.Errorf("GETBULK not supported in SNMPv1")
+	}
 	oidCount := len(oids)
 	if oidCount > x.MaxOids {
 		return nil, fmt.Errorf("oid count (%d) is greater than MaxOids (%d)",


### PR DESCRIPTION
Changed GetBulk so it returns an explicit error when called with Version1.
Added matching test.
Documented GETBULK support in README.md
Added SNMPv1 as explicitely supported in README.
Fixes #288