### PR TITLE
Support for e2e tests against net-snmpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ RUN apk add --no-cache  \
         gcc             \
         libc-dev        \
         make            \
+        net-snmp        \
+        net-snmp-tools  \
         python3         \
-        py3-pip
+        py3-pip         \
+        vim
 
 # add new user
 RUN addgroup -g 1001                \
@@ -18,6 +21,7 @@ RUN addgroup -g 1001                \
             -h /home/gosnmp         \
             -G gosnmp gosnmp
 
+RUN chmod -R a+rw /etc/snmp /var/lib/net-snmp/
 RUN pip install snmpsim
 
 # Copy local branch into container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14.4-alpine3.12
+FROM golang:1.15-alpine3.13
 
 # Install deps
 RUN apk add --no-cache  \
@@ -9,6 +9,7 @@ RUN apk add --no-cache  \
         make            \
         net-snmp        \
         net-snmp-tools  \
+        openssl-dev     \
         python3         \
         py3-pip         \
         vim
@@ -39,5 +40,6 @@ ENV GOSNMP_TARGET_IPV4=127.0.0.1
 ENV GOSNMP_PORT_IPV4=1024
 ENV GOSNMP_TARGET_IPV6='::1'
 ENV GOSNMP_PORT_IPV6=1024
+ENV GOSNMP_SNMPD=true
 
 ENTRYPOINT ["/go/src/github.com/gosnmp/gosnmp/build_tests.sh"]

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 
-snmpsimd.py --logging-method=null --agent-udpv4-endpoint=127.0.0.1:1024 &
+if [ "${GOSNMP_SNMPD}" != "" ]; then
+    echo "Using real net-snmp server"
+    ./snmp_users.sh
+    sed -i -e 's/^agentAddress.*/agentAddress udp:127.0.0.1:1024/' /etc/snmp/snmpd.conf
+    sed -i -e 's/ localhost / 127.0.0.1 /' /etc/snmp/snmpd.conf
+    sed -i -e 's/.*trapsink.*//' /etc/snmp/snmpd.conf
+    sed -i -e 's/.*master\s*agentx//' /etc/snmp/snmpd.conf
+    snmpd
+else
+    echo "Using snmpsimd simultator"
+    snmpsimd.py --logging-method=null --agent-udpv4-endpoint=127.0.0.1:1024 &
+fi
+
 go test -v -tags helper
 go test -v -tags marshal
 go test -v -tags misc

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "${GOSNMP_SNMPD}" != "" ]; then
-    echo "Using real net-snmp server"
+    echo "Using $(snmpd --version | awk /version:/)"
     ./snmp_users.sh
     sed -i -e 's/^agentAddress.*/agentAddress udp:127.0.0.1:1024/' /etc/snmp/snmpd.conf
     sed -i -e 's/ localhost / 127.0.0.1 /' /etc/snmp/snmpd.conf
@@ -9,7 +9,7 @@ if [ "${GOSNMP_SNMPD}" != "" ]; then
     sed -i -e 's/.*master\s*agentx//' /etc/snmp/snmpd.conf
     snmpd
 else
-    echo "Using snmpsimd simultator"
+    echo "Using snmpsimd simulator"
     snmpsimd.py --logging-method=null --agent-udpv4-endpoint=127.0.0.1:1024 &
 fi
 


### PR DESCRIPTION
Updated Dockerfile & entrypoint to support "real" snmpd server.
This makes it easier to test https://github.com/gosnmp/gosnmp/pull/289 for instance.

Signed-off-by: Michel Blanc <mb@devops.works>