### PR TITLE
Makefile: bump golangci-lint to v1.36.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ lint:
 	golangci-lint run -v
 
 tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.32.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.36.0


### PR DESCRIPTION
Signed-off-by: Tim Rots <tim.rots@protonmail.ch>