### PR TITLE
marshalPDU(): stricter integer conversion

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -360,7 +360,7 @@ func marshalUint64(v interface{}) ([]byte, error) {
 	return bytes.TrimLeft(bs, "\x00"), nil
 }
 
-// Counter32, Gauge32, TimeTicks, Unsigned32
+// Counter32, Gauge32, TimeTicks, Unsigned32, SNMPError
 func marshalUint32(v interface{}) ([]byte, error) {
 	bs := make([]byte, 4)
 
@@ -370,9 +370,10 @@ func marshalUint32(v interface{}) ([]byte, error) {
 		source = val
 	case uint:
 		source = uint32(val)
+	case uint8:
+		source = uint32(val)
 	// We could do others here, but coercing from anything else is dangerous.
-	// Even uint could be 64 bits, though in practice nothing we work with here
-	// is.
+	// Even uint could be 64 bits, though in practice nothing we work with is.
 	default:
 		return nil, fmt.Errorf("unable to marshal %T to uint32", v)
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -533,7 +533,15 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		}
 
 		// non repeaters
-		buf.Write([]byte{2, 1, packet.NonRepeaters})
+		nonRepeaters, err := marshalUint32(packet.NonRepeaters)
+		if err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters to uint32: %s", err.Error())
+		}
+
+		buf.Write([]byte{2, byte(len(nonRepeaters))})
+		if err = binary.Write(buf, binary.BigEndian, nonRepeaters); err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters: %s", err.Error())
+		}
 
 		// max repetitions
 		maxRepetitions, err := marshalUint32(packet.MaxRepetitions)
@@ -563,34 +571,52 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 			return nil, fmt.Errorf("unable to marshal OID: %s", err.Error())
 		}
 
-		// error
-		buf.Write([]byte{2, 1, byte(packet.Error)})
+		// error status
+		errorStatus, err := marshalUint32(uint8(packet.Error))
+		if err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus to uint32: %s", err.Error())
+		}
+
+		buf.Write([]byte{2, byte(len(errorStatus))})
+		if err = binary.Write(buf, binary.BigEndian, errorStatus); err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus: %s", err.Error())
+		}
 
 		// error index
-		buf.Write([]byte{2, 1, packet.ErrorIndex})
+		errorIndex, err := marshalUint32(packet.ErrorIndex)
+		if err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex to uint32: %s", err.Error())
+		}
+
+		buf.Write([]byte{2, byte(len(errorIndex))})
+		if err = binary.Write(buf, binary.BigEndian, errorIndex); err != nil {
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex: %s", err.Error())
+		}
 	}
 
-	// varbind list
+	// build varbind list
 	vbl, err := packet.marshalVBL()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshalPDU: unable to marshal varbind list: %s", err.Error())
 	}
 	buf.Write(vbl)
 
-	// build up resulting pdu - request type, length, then the tail (buf)
+	// build up resulting pdu
 	pdu := new(bytes.Buffer)
-	pdu.WriteByte(byte(packet.PDUType))
-
-	bufLengthBytes, err2 := marshalLength(buf.Len())
-	if err2 != nil {
-		return nil, err2
-	}
-	pdu.Write(bufLengthBytes)
-
-	_, err = buf.WriteTo(pdu)
+	// calculate pdu length
+	bufLengthBytes, err := marshalLength(buf.Len())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu length: %s", err.Error())
 	}
+	// write request type
+	pdu.WriteByte(byte(packet.PDUType))
+	// write pdu length
+	pdu.Write(bufLengthBytes)
+	// write the tail (buf)
+	if _, err = buf.WriteTo(pdu); err != nil {
+		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu: %s", err.Error())
+	}
+
 	return pdu.Bytes(), nil
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -535,23 +535,23 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		// non repeaters
 		nonRepeaters, err := marshalUint32(packet.NonRepeaters)
 		if err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters to uint32: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters to uint32: %w", err)
 		}
 
 		buf.Write([]byte{2, byte(len(nonRepeaters))})
 		if err = binary.Write(buf, binary.BigEndian, nonRepeaters); err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal NonRepeaters: %w", err)
 		}
 
 		// max repetitions
 		maxRepetitions, err := marshalUint32(packet.MaxRepetitions)
 		if err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions to uint32: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions to uint32: %w", err)
 		}
 
 		buf.Write([]byte{2, byte(len(maxRepetitions))})
 		if err = binary.Write(buf, binary.BigEndian, maxRepetitions); err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions: %w", err)
 		}
 
 	case Trap:
@@ -568,36 +568,36 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		buf.Write([]byte{2, 4})
 		err := binary.Write(buf, binary.BigEndian, packet.RequestID)
 		if err != nil {
-			return nil, fmt.Errorf("unable to marshal OID: %s", err.Error())
+			return nil, fmt.Errorf("unable to marshal OID: %w", err)
 		}
 
 		// error status
 		errorStatus, err := marshalUint32(uint8(packet.Error))
 		if err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus to uint32: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus to uint32: %w", err)
 		}
 
 		buf.Write([]byte{2, byte(len(errorStatus))})
 		if err = binary.Write(buf, binary.BigEndian, errorStatus); err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorStatus: %w", err)
 		}
 
 		// error index
 		errorIndex, err := marshalUint32(packet.ErrorIndex)
 		if err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex to uint32: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex to uint32: %w", err)
 		}
 
 		buf.Write([]byte{2, byte(len(errorIndex))})
 		if err = binary.Write(buf, binary.BigEndian, errorIndex); err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal errorIndex: %w", err)
 		}
 	}
 
 	// build varbind list
 	vbl, err := packet.marshalVBL()
 	if err != nil {
-		return nil, fmt.Errorf("marshalPDU: unable to marshal varbind list: %s", err.Error())
+		return nil, fmt.Errorf("marshalPDU: unable to marshal varbind list: %w", err)
 	}
 	buf.Write(vbl)
 
@@ -606,7 +606,7 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 	// calculate pdu length
 	bufLengthBytes, err := marshalLength(buf.Len())
 	if err != nil {
-		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu length: %s", err.Error())
+		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu length: %w", err)
 	}
 	// write request type
 	pdu.WriteByte(byte(packet.PDUType))
@@ -614,7 +614,7 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 	pdu.Write(bufLengthBytes)
 	// write the tail (buf)
 	if _, err = buf.WriteTo(pdu); err != nil {
-		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu: %s", err.Error())
+		return nil, fmt.Errorf("marshalPDU: unable to marshal pdu: %w", err)
 	}
 
 	return pdu.Bytes(), nil


### PR DESCRIPTION
This PR is a (non-breaking) iteration on #295 to address the
remaining comments mentioned in issue #293

#### marshal.go/marshalPDU():
* Improve integer conversion safety
* Improve error messages
* Fix code styling
#### helper.go/marshalUint32():
* Add uint8 to helper

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>