### PR TITLE
Use Go 1.13 error wrapping

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -284,13 +284,13 @@ func (x *GoSNMP) connect(networkSuffix string) error {
 
 	x.Transport += networkSuffix
 	if err = x.netConnect(); err != nil {
-		return fmt.Errorf("error establishing connection to host: %s", err.Error())
+		return fmt.Errorf("error establishing connection to host: %w", err)
 	}
 
 	if x.random == 0 {
 		n, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32)) // returns a uniform random value in [0, 2147483647].
 		if err != nil {
-			return fmt.Errorf("error occurred while generating random: %s", err.Error())
+			return fmt.Errorf("error occurred while generating random: %w", err)
 		}
 		x.random = uint32(n.Uint64())
 	}
@@ -527,7 +527,7 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 	var cursor int
 	cursor, err = x.unmarshalHeader(resp, result)
 	if err != nil {
-		err = fmt.Errorf("unable to decode packet header: %s", err.Error())
+		err = fmt.Errorf("unable to decode packet header: %w", err)
 		return result, err
 	}
 
@@ -540,7 +540,7 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 
 	err = x.unmarshalPayload(resp, cursor, result)
 	if err != nil {
-		err = fmt.Errorf("unable to decode packet body: %s", err.Error())
+		err = fmt.Errorf("unable to decode packet body: %w", err)
 		return result, err
 	}
 

--- a/helper.go
+++ b/helper.go
@@ -474,14 +474,14 @@ func marshalOID(oid string) ([]byte, error) {
 	for i := 0; i < len(oidParts); i++ {
 		oidBytes[i], err = strconv.Atoi(oidParts[i])
 		if err != nil {
-			return nil, fmt.Errorf("unable to parse OID: %s", err.Error())
+			return nil, fmt.Errorf("unable to parse OID: %w", err)
 		}
 	}
 
 	mOid, err := marshalObjectIdentifier(oidBytes)
 
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal OID: %s", err.Error())
+		return nil, fmt.Errorf("unable to marshal OID: %w", err)
 	}
 
 	return mOid, err

--- a/marshal.go
+++ b/marshal.go
@@ -478,7 +478,7 @@ func (packet *SnmpPacket) marshalSNMPV1TrapHeader() ([]byte, error) {
 	// marshal OID
 	oidBytes, err := marshalOID(packet.Enterprise)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal OID: %s", err.Error())
+		return nil, fmt.Errorf("unable to marshal OID: %w", err)
 	}
 	buf.Write([]byte{byte(ObjectIdentifier), byte(len(oidBytes))})
 	buf.Write(oidBytes)
@@ -494,7 +494,7 @@ func (packet *SnmpPacket) marshalSNMPV1TrapHeader() ([]byte, error) {
 	var genericTrapBytes []byte
 	genericTrapBytes, err = marshalInt32(packet.GenericTrap)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal SNMPv1 GenericTrap: %s", err.Error())
+		return nil, fmt.Errorf("unable to marshal SNMPv1 GenericTrap: %w", err)
 	}
 	buf.Write([]byte{byte(Integer), byte(len(genericTrapBytes))})
 	buf.Write(genericTrapBytes)
@@ -503,7 +503,7 @@ func (packet *SnmpPacket) marshalSNMPV1TrapHeader() ([]byte, error) {
 	var specificTrapBytes []byte
 	specificTrapBytes, err = marshalInt32(packet.SpecificTrap)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal SNMPv1 SpecificTrap: %s", err.Error())
+		return nil, fmt.Errorf("unable to marshal SNMPv1 SpecificTrap: %w", err)
 	}
 	buf.Write([]byte{byte(Integer), byte(len(specificTrapBytes))})
 	buf.Write(specificTrapBytes)
@@ -538,12 +538,12 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		// max repetitions
 		maxRepetitions, err := marshalUint32(packet.MaxRepetitions)
 		if err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions to uint32: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions to uint32: %w", err)
 		}
 
 		buf.Write([]byte{2, byte(len(maxRepetitions))})
 		if err = binary.Write(buf, binary.BigEndian, maxRepetitions); err != nil {
-			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions: %s", err.Error())
+			return nil, fmt.Errorf("marshalPDU: unable to marshal maxRepetitions: %w", err)
 		}
 
 	case Trap:
@@ -560,7 +560,7 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 		buf.Write([]byte{2, 4})
 		err := binary.Write(buf, binary.BigEndian, packet.RequestID)
 		if err != nil {
-			return nil, fmt.Errorf("unable to marshal OID: %s", err.Error())
+			return nil, fmt.Errorf("unable to marshal OID: %w", err)
 		}
 
 		// error
@@ -866,7 +866,7 @@ func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, erro
 	// Parse SNMP Version
 	rawVersion, count, err := parseRawField(x.Logger, packet[cursor:], "version")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMP packet version: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMP packet version: %w", err)
 	}
 
 	cursor += count
@@ -890,7 +890,7 @@ func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, erro
 		// Parse community
 		rawCommunity, count, err := parseRawField(x.Logger, packet[cursor:], "community")
 		if err != nil {
-			return 0, fmt.Errorf("error parsing community string: %s", err.Error())
+			return 0, fmt.Errorf("error parsing community string: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -916,7 +916,7 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 		response.PDUType = requestType
 		err = x.unmarshalResponse(packet[cursor:], response)
 		if err != nil {
-			return fmt.Errorf("error in unmarshalResponse: %s", err.Error())
+			return fmt.Errorf("error in unmarshalResponse: %w", err)
 		}
 		// If it's an InformRequest, mark the trap.
 		response.IsInform = (requestType == InformRequest)
@@ -924,7 +924,7 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 		response.PDUType = requestType
 		err = x.unmarshalTrapV1(packet[cursor:], response)
 		if err != nil {
-			return fmt.Errorf("error in unmarshalTrapV1: %s", err.Error())
+			return fmt.Errorf("error in unmarshalTrapV1: %w", err)
 		}
 	default:
 		x.logPrintf("UnmarshalPayload Meet Unknown PDUType %#x. Offset %v", requestType, cursor)
@@ -945,7 +945,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 	// Parse Request-ID
 	rawRequestID, count, err := parseRawField(x.Logger, packet[cursor:], "request id")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet request ID: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet request ID: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -961,7 +961,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		// Parse Non Repeaters
 		rawNonRepeaters, count, err := parseRawField(x.Logger, packet[cursor:], "non repeaters")
 		if err != nil {
-			return fmt.Errorf("error parsing SNMP packet non repeaters: %s", err.Error())
+			return fmt.Errorf("error parsing SNMP packet non repeaters: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -975,7 +975,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		// Parse Max Repetitions
 		rawMaxRepetitions, count, err := parseRawField(x.Logger, packet[cursor:], "max repetitions")
 		if err != nil {
-			return fmt.Errorf("error parsing SNMP packet max repetitions: %s", err.Error())
+			return fmt.Errorf("error parsing SNMP packet max repetitions: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -989,7 +989,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		// Parse Error-Status
 		rawError, count, err := parseRawField(x.Logger, packet[cursor:], "error-status")
 		if err != nil {
-			return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+			return fmt.Errorf("error parsing SNMP packet error: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -1004,7 +1004,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		// Parse Error-Index
 		rawErrorIndex, count, err := parseRawField(x.Logger, packet[cursor:], "error index")
 		if err != nil {
-			return fmt.Errorf("error parsing SNMP packet error index: %s", err.Error())
+			return fmt.Errorf("error parsing SNMP packet error index: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -1032,7 +1032,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	// Parse Enterprise
 	rawEnterprise, count, err := parseRawField(x.Logger, packet[cursor:], "enterprise")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -1047,7 +1047,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	// Parse AgentAddress
 	rawAgentAddress, count, err := parseRawField(x.Logger, packet[cursor:], "agent-address")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -1062,7 +1062,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	// Parse GenericTrap
 	rawGenericTrap, count, err := parseRawField(x.Logger, packet[cursor:], "generic-trap")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -1077,7 +1077,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	// Parse SpecificTrap
 	rawSpecificTrap, count, err := parseRawField(x.Logger, packet[cursor:], "specific-trap")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -1092,7 +1092,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	// Parse TimeStamp
 	rawTimestamp, count, err := parseRawField(x.Logger, packet[cursor:], "time-stamp")
 	if err != nil {
-		return fmt.Errorf("error parsing SNMP packet error: %s", err.Error())
+		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -1150,7 +1150,7 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		// Parse OID
 		rawOid, oidLength, err := parseRawField(x.Logger, packet[cursor:], "OID")
 		if err != nil {
-			return fmt.Errorf("error parsing OID Value: %s", err.Error())
+			return fmt.Errorf("error parsing OID Value: %w", err)
 		}
 
 		cursor += oidLength
@@ -1197,7 +1197,7 @@ func (x *GoSNMP) receive() ([]byte, error) {
 	if err == io.EOF {
 		return nil, err
 	} else if err != nil {
-		return nil, fmt.Errorf("error reading from socket: %s", err.Error())
+		return nil, fmt.Errorf("error reading from socket: %w", err)
 	}
 
 	if n == rxBufSize {

--- a/v3.go
+++ b/v3.go
@@ -344,7 +344,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 
 	rawMsgID, count, err := parseRawField(x.Logger, packet[cursor:], "msgID")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 message ID: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 message ID: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -358,7 +358,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 
 	rawMsgMaxSize, count, err := parseRawField(x.Logger, packet[cursor:], "msgMaxSize")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 msgMaxSize: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 msgMaxSize: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -372,7 +372,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 
 	rawMsgFlags, count, err := parseRawField(x.Logger, packet[cursor:], "msgFlags")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 msgFlags: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 msgFlags: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -386,7 +386,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 
 	rawSecModel, count, err := parseRawField(x.Logger, packet[cursor:], "msgSecurityModel")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 msgSecModel: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 msgSecModel: %w", err)
 	}
 	cursor += count
 	if cursor > len(packet) {
@@ -454,7 +454,7 @@ func (x *GoSNMP) decryptPacket(packet []byte, cursor int, response *SnmpPacket) 
 
 		rawContextEngineID, count, err := parseRawField(x.Logger, packet[cursor:], "contextEngineID")
 		if err != nil {
-			return nil, 0, fmt.Errorf("error parsing SNMPV3 contextEngineID: %s", err.Error())
+			return nil, 0, fmt.Errorf("error parsing SNMPV3 contextEngineID: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {
@@ -467,7 +467,7 @@ func (x *GoSNMP) decryptPacket(packet []byte, cursor int, response *SnmpPacket) 
 		}
 		rawContextName, count, err := parseRawField(x.Logger, packet[cursor:], "contextName")
 		if err != nil {
-			return nil, 0, fmt.Errorf("error parsing SNMPV3 contextName: %s", err.Error())
+			return nil, 0, fmt.Errorf("error parsing SNMPV3 contextName: %w", err)
 		}
 		cursor += count
 		if cursor > len(packet) {

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -353,14 +353,14 @@ func (sp *UsmSecurityParameters) init(log Logger) error {
 		salt := make([]byte, 8)
 		_, err = crand.Read(salt)
 		if err != nil {
-			return fmt.Errorf("error creating a cryptographically secure salt: %s", err.Error())
+			return fmt.Errorf("error creating a cryptographically secure salt: %w", err)
 		}
 		sp.localAESSalt = binary.BigEndian.Uint64(salt)
 	case DES:
 		salt := make([]byte, 4)
 		_, err = crand.Read(salt)
 		if err != nil {
-			return fmt.Errorf("error creating a cryptographically secure salt: %s", err.Error())
+			return fmt.Errorf("error creating a cryptographically secure salt: %w", err)
 		}
 		sp.localDESSalt = binary.BigEndian.Uint32(salt)
 	}
@@ -841,7 +841,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgAuthoritativeEngineID, count, err := parseRawField(sp.Logger, packet[cursor:], "msgAuthoritativeEngineID")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineID: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineID: %w", err)
 	}
 	cursor += count
 	if AuthoritativeEngineID, ok := rawMsgAuthoritativeEngineID.(string); ok {
@@ -860,7 +860,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgAuthoritativeEngineBoots, count, err := parseRawField(sp.Logger, packet[cursor:], "msgAuthoritativeEngineBoots")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineBoots: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineBoots: %w", err)
 	}
 	cursor += count
 	if AuthoritativeEngineBoots, ok := rawMsgAuthoritativeEngineBoots.(int); ok {
@@ -870,7 +870,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgAuthoritativeEngineTime, count, err := parseRawField(sp.Logger, packet[cursor:], "msgAuthoritativeEngineTime")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineTime: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthoritativeEngineTime: %w", err)
 	}
 	cursor += count
 	if AuthoritativeEngineTime, ok := rawMsgAuthoritativeEngineTime.(int); ok {
@@ -880,7 +880,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgUserName, count, err := parseRawField(sp.Logger, packet[cursor:], "msgUserName")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgUserName: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgUserName: %w", err)
 	}
 	cursor += count
 	if msgUserName, ok := rawMsgUserName.(string); ok {
@@ -890,7 +890,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgAuthParameters, count, err := parseRawField(sp.Logger, packet[cursor:], "msgAuthenticationParameters")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthenticationParameters: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgAuthenticationParameters: %w", err)
 	}
 	if msgAuthenticationParameters, ok := rawMsgAuthParameters.(string); ok {
 		sp.AuthenticationParameters = msgAuthenticationParameters
@@ -904,7 +904,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 
 	rawMsgPrivacyParameters, count, err := parseRawField(sp.Logger, packet[cursor:], "msgPrivacyParameters")
 	if err != nil {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgPrivacyParameters: %s", err.Error())
+		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model msgPrivacyParameters: %w", err)
 	}
 	cursor += count
 	if msgPrivacyParameters, ok := rawMsgPrivacyParameters.(string); ok {


### PR DESCRIPTION
Allow use of `errors.Is()` by using %w error format wrapping.

Signed-off-by: Ben Kochie <superq@gmail.com>