### PR TITLE
walk.go: improve BulkWalk error handling

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -60,9 +60,63 @@ RequestLoop:
 			break RequestLoop
 		}
 
-		if response.Error == NoSuchName {
+		switch response.Error {
+		case TooBig:
+			x.Logger.Print("Walk terminated with TooBig")
+			break RequestLoop
+		case NoSuchName:
 			x.Logger.Print("Walk terminated with NoSuchName")
 			break RequestLoop
+		case BadValue:
+			x.Logger.Print("Walk terminated with BadValue")
+			break RequestLoop
+		case ReadOnly:
+			x.Logger.Print("Walk terminated with ReadOnly")
+			break RequestLoop
+		case GenErr:
+			x.Logger.Print("Walk terminated with GenErr")
+			break RequestLoop
+		case NoAccess:
+			x.Logger.Print("Walk terminated with NoAccess")
+			break RequestLoop
+		case WrongType:
+			x.Logger.Print("Walk terminated with WrongType")
+			break RequestLoop
+		case WrongLength:
+			x.Logger.Print("Walk terminated with WrongLength")
+			break RequestLoop
+		case WrongEncoding:
+			x.Logger.Print("Walk terminated with WrongEncoding")
+			break RequestLoop
+		case WrongValue:
+			x.Logger.Print("Walk terminated with WrongValue")
+			break RequestLoop
+		case NoCreation:
+			x.Logger.Print("Walk terminated with NoCreation")
+			break RequestLoop
+		case InconsistentValue:
+			x.Logger.Print("Walk terminated with InconsistentValue")
+			break RequestLoop
+		case ResourceUnavailable:
+			x.Logger.Print("Walk terminated with ResourceUnavailable")
+			break RequestLoop
+		case CommitFailed:
+			x.Logger.Print("Walk terminated with CommitFailed")
+			break RequestLoop
+		case UndoFailed:
+			x.Logger.Print("Walk terminated with UndoFailed")
+			break RequestLoop
+		case AuthorizationError:
+			x.Logger.Print("Walk terminated with AuthorizationError")
+			break RequestLoop
+		case NotWritable:
+			x.Logger.Print("Walk terminated with NotWritable")
+			break RequestLoop
+		case InconsistentName:
+			x.Logger.Print("Walk terminated with InconsistentName")
+			break RequestLoop
+		case NoError:
+			x.Logger.Print("Walk completed with NoError")
 		}
 
 		for i, pdu := range response.Variables {


### PR DESCRIPTION
* Improve snmp packet level error checks in BulkWalk()

Fixes #291

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>