### PR TITLE
marshal.go: updatePktSecurityParameters called with non v3 packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 * [ENHANCEMENT]
 * [BUGFIX]
 
+## Unreleased
+
 NOTE:
 
-* [BUGFIX] Add validation to prevent calling updatePktSecurityParameters with non v3 packet #314
+* [BUGFIX] Add validation to prevent calling updatePktSecurityParameters with non v3 packet #251 #314
 
 ## v1.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 NOTE:
 
+* [BUGFIX] Add validation to prevent calling updatePktSecurityParameters with non v3 packet #314
+
 ## v1.30.0
 
 NOTE: This release changes the MaxRepetitions type to uint32.

--- a/marshal.go
+++ b/marshal.go
@@ -97,7 +97,18 @@ const (
 	GetBulkRequest PDUType = 0xa5
 	InformRequest  PDUType = 0xa6
 	SNMPv2Trap     PDUType = 0xa7 // v2c, v3
-	Report         PDUType = 0xa8
+	Report         PDUType = 0xa8 // v3
+)
+
+// SNMPv3: User-based Security Model Report PDUs
+// as per https://tools.ietf.org/html/rfc3414.html
+const (
+	usmStatsUnsupportedSecLevels = ".1.3.6.1.6.3.15.1.1.1.0"
+	usmStatsNotInTimeWindows     = ".1.3.6.1.6.3.15.1.1.2.0"
+	usmStatsUnknownUserNames     = ".1.3.6.1.6.3.15.1.1.3.0"
+	usmStatsUnknownEngineIDs     = ".1.3.6.1.6.3.15.1.1.4.0"
+	usmStatsWrongDigests         = ".1.3.6.1.6.3.15.1.1.5.0"
+	usmStatsDecryptionErrors     = ".1.3.6.1.6.3.15.1.1.6.0"
 )
 
 const rxBufSize = 65535 // max size of IPv4 & IPv6 packet
@@ -295,15 +306,39 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				continue
 			}
 
-			// Detect usmStats report PDUs and go out of this function with all data
-			// (usmStatsNotInTimeWindows [1.3.6.1.6.3.15.1.1.2.0] will be handled by the calling
-			// function, and retransmitted.  All others need to be handled by user code)
-			if result.Version == Version3 && len(result.Variables) == 1 && result.PDUType == Report {
+			// While Report PDU was defined by RFC 1905 as part of SNMPv2, it was never
+			// used until SNMPv3. Report PDU's allow a SNMP engine to tell another SNMP
+			// engine that an error was detected while processing an SNMP message.
+			//
+			// The format for a Report PDU is
+			// -----------------------------------
+			// | 0xA8 | reqid | 0 | 0 | varbinds |
+			// -----------------------------------
+			// where:
+			// - PDU type 0xA8 indicates a Report PDU.
+			// - reqid is either:
+			//    The request identifier of the message that triggered the report
+			//    or zero if the request identifier cannot be extracted.
+			// - The variable bindings will contain a single object identifier and its value
+			//
+			// usmStatsNotInTimeWindows and usmStatsUnknownEngineIDs are recoverable errors
+			// and will be retransmitted, for others we return the result with an error.
+			if result.Version == Version3 && result.PDUType == Report && len(result.Variables) == 1 {
 				switch result.Variables[0].Name {
-				case ".1.3.6.1.6.3.15.1.1.1.0", ".1.3.6.1.6.3.15.1.1.2.0",
-					".1.3.6.1.6.3.15.1.1.3.0", ".1.3.6.1.6.3.15.1.1.4.0",
-					".1.3.6.1.6.3.15.1.1.5.0", ".1.3.6.1.6.3.15.1.1.6.0":
+				case usmStatsUnsupportedSecLevels:
+					return result, fmt.Errorf("error: unknown security level")
+				case usmStatsNotInTimeWindows:
 					break waitingResponse
+				case usmStatsUnknownUserNames:
+					return result, fmt.Errorf("error: unknown username")
+				case usmStatsUnknownEngineIDs:
+					break waitingResponse
+				case usmStatsWrongDigests:
+					return result, fmt.Errorf("error: wrong digest")
+				case usmStatsDecryptionErrors:
+					return result, fmt.Errorf("error: decryption error")
+				default:
+					return result, fmt.Errorf("error: received unknown Report PDU %v", result.Variables[0].Name)
 				}
 			}
 
@@ -355,6 +390,7 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 		return nil, fmt.Errorf("&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 	}
 
+	// detected unknown engine id error,
 	if x.Retries < 0 {
 		x.Retries = 0
 	}
@@ -378,36 +414,37 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 		x.logPrintf("SEND STORE SECURITY PARAMS from result: %+v", result)
 		err = x.storeSecurityParameters(result)
 
-		// detect out-of-time-window error and retransmit with updated auth engine parameters
-		if len(result.Variables) == 1 && result.Variables[0].Name == ".1.3.6.1.6.3.15.1.1.2.0" {
-			x.logPrint("WARNING detected out-of-time-window ERROR")
-			err = x.updatePktSecurityParameters(packetOut)
-			if err != nil {
-				x.logPrintf("ERROR  updatePktSecurityParameters error: %s", err)
-				return nil, err
+		// v3: check for recoverable errors
+		if result.PDUType == Report && len(result.Variables) == 1 {
+			switch result.Variables[0].Name {
+			case usmStatsNotInTimeWindows:
+				// detected out-of-time-window error,
+				x.logPrint("WARNING detected out-of-time-window ERROR")
+				if err = x.updatePktSecurityParameters(packetOut); err != nil {
+					x.logPrintf("ERROR  updatePktSecurityParameters error: %s", err)
+					return nil, err
+				}
+				// retransmit with updated auth engine params
+				result, err = x.sendOneRequest(packetOut, wait)
+				if err != nil {
+					x.logPrintf("ERROR  out-of-time-window retransmit error: %s", err)
+					return result, err
+				}
+
+			case usmStatsUnknownEngineIDs:
+				// detected unknown engine id error,
+				x.logPrint("WARNING detected unknown engine id ERROR")
+				if err = x.updatePktSecurityParameters(packetOut); err != nil {
+					x.logPrintf("ERROR  updatePktSecurityParameters error: %s", err)
+					return nil, err
+				}
+				// retransmit with updated engine id
+				result, err = x.sendOneRequest(packetOut, wait)
+				if err != nil {
+					x.logPrintf("ERROR unknown engine id retransmit error: %s", err)
+					return result, err
+				}
 			}
-
-			result, err = x.sendOneRequest(packetOut, wait)
-			if err != nil {
-				x.logPrintf("ERROR  out-of-time-window retransmit error: %s", err)
-				return nil, err
-			}
-		}
-	}
-
-	// detect unknown engine id error and retransmit with updated engine id
-	if len(result.Variables) == 1 && result.Variables[0].Name == ".1.3.6.1.6.3.15.1.1.4.0" {
-		x.logPrint("WARNING detected unknown engine id ERROR")
-		err = x.updatePktSecurityParameters(packetOut)
-		if err != nil {
-			x.logPrintf("ERROR  updatePktSecurityParameters error: %s", err)
-			return nil, err
-		}
-
-		result, err = x.sendOneRequest(packetOut, wait)
-		if err != nil {
-			x.logPrintf("ERROR unknown engine id retransmit error: %s", err)
-			return nil, err
 		}
 	}
 	return result, err


### PR DESCRIPTION
### marshal.go/sendOneRequest():
- Add v3 PDU Report documentation
- Add error handling for non-recoverable cases
### marshal.go/send():
-  Add validation to prevent calling ``updatePktSecurityParameters`` with non v3 packet 

Fixes  #251  #307

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>
Co-Authored-by: Thomas Casteleyn <thomas.casteleyn@super-visions.com>