### PR TITLE
v3_usm.go: Fix UsmSecurityParameters.Description comment

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -41,7 +41,7 @@ type testsEnmarshalVarbindPosition struct {
 		what's actually happening
 
 		2) for counting byte positions: select "Simple Network Management
-		Protocal" line in Wiresharks middle pane, then right click and choose
+		Protocol" line in Wiresharks middle pane, then right click and choose
 		"Export Packet Bytes..." (as .raw). Open the capture in wireshark, it
 		will decode as "BER Encoded File". Click on each varbind and the
 		"packet bytes" window will highlight the corresponding bytes, then the
@@ -1723,7 +1723,7 @@ func dumpBytes1(data []byte, msg string, maxlength int) {
 	if len(data) < maxlength {
 		length = len(data)
 	}
-	length *= 2 //One Byte Symobls Two Hex
+	length *= 2 //One Byte Symbols Two Hex
 	hexStr := hex.EncodeToString(data)
 	for i := 0; length >= i+16; i += 16 {
 		buffer.WriteString("\n")

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -154,7 +154,7 @@ type UsmSecurityParameters struct {
 	Logger Logger
 }
 
-// Log logs security paramater information to the provided GoSNMP Logger
+// Description logs authentication paramater information to the provided GoSNMP Logger
 func (sp *UsmSecurityParameters) Description() string {
 	var sb strings.Builder
 	sb.WriteString("user=")


### PR DESCRIPTION
* Fix duplicate description comment for ``UsmSecurityParameters.Description()``

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>