### PR TITLE
gosnmp.go: remove double locking in validateParameters

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -18,7 +18,6 @@ import (
 	"math/big"
 	"net"
 	"strconv"
-	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -42,8 +41,6 @@ const (
 
 // GoSNMP represents GoSNMP library state.
 type GoSNMP struct {
-	mu sync.Mutex
-
 	// Conn is net connection to use, typically established using GoSNMP.Connect().
 	Conn net.Conn
 
@@ -337,12 +334,10 @@ func (x *GoSNMP) netConnect() error {
 }
 
 func (x *GoSNMP) validateParameters() error {
-	if x.Logger == nil {
-		x.mu.Lock()
-		defer x.mu.Unlock()
-		x.Logger = log.New(ioutil.Discard, "", 0)
-	} else {
+	if x.Logger != nil {
 		x.loggingEnabled = true
+	} else {
+		x.Logger = log.New(ioutil.Discard, "", 0)
 	}
 
 	if x.Transport == "" {


### PR DESCRIPTION
* Remove 'double' locking in validateParameters() as write operations to the underlying Logger object are [atomic](https://github.com/golang/go/blob/master/src/log/log.go#L49)
* Simplify flow

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>