### PR TITLE
return received SNMP error code immediately instead wait timeout

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -312,8 +312,8 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				x.logPrintf("ERROR on UnmarshalPayload on v3: %s", err)
 				continue
 			}
-			if len(result.Variables) < 1 {
-				x.logPrintf("ERROR on UnmarshalPayload on v3: %s", err)
+			if result.Error == NoError && len(result.Variables) < 1 {
+				x.logPrintf("ERROR on UnmarshalPayload on v3: Empty result")
 				continue
 			}
 


### PR DESCRIPTION
There is currently an issue processing the SNMP Get response:
If the device responded to the snmp get request with an error, for example (tooBig response) when the maximum number of oids was exceeded, then instead of immediately completing the processing of the received packet, the library tries to retry the request again if the number of attempts is specified.
Also, the received error code is lost. It should be in SnmpPacket.Error, but in fact it contains the NoError value.

This fix allows you to stop processing the snmp response, and immediately return the received SNMP error code instead of waiting for retries, saving the error code.