### PR TITLE
Code cleanup

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -539,10 +539,6 @@ func (x *GoSNMP) SnmpDecodePacket(resp []byte) (*SnmpPacket, error) {
 		return result, err
 	}
 
-	// if result == nil {
-	// 	err = fmt.Errorf("Unable to decode packet: no variables")
-	// 	return result, err
-	// }
 	return result, nil
 }
 

--- a/helper.go
+++ b/helper.go
@@ -64,7 +64,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (*variable, error) {
 	}
 
 	if len(data) == 0 {
-		return nil, fmt.Errorf("err: zero byte buffer")
+		return nil, errors.New("zero byte buffer")
 	}
 
 	// values matching this mask have the type in subsequent byte
@@ -87,7 +87,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (*variable, error) {
 		var err2 error
 		if ret, err2 = parseInt(data[cursor:length]); err2 != nil {
 			x.logPrintf("%v:", err2)
-			return nil, fmt.Errorf("bytes: % x err: %v", data, err2)
+			return nil, fmt.Errorf("bytes: % x err: %w", data, err2)
 		}
 		retVal.Type = Integer
 		retVal.Value = ret
@@ -111,7 +111,7 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (*variable, error) {
 		x.logPrint("decodeValue: type is ObjectIdentifier")
 		rawOid, _, err2 := parseRawField(x.Logger, data, "OID")
 		if err2 != nil {
-			return nil, fmt.Errorf("error parsing OID Value: %s", err2.Error())
+			return nil, fmt.Errorf("error parsing OID Value: %w", err2)
 		}
 		var oid []int
 		var ok bool
@@ -511,7 +511,7 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 	offset = initOffset
 	for shifted := 0; offset < len(bytes); shifted++ {
 		if shifted > 4 {
-			err = fmt.Errorf("structural error: base 128 integer too large")
+			err = errors.New("structural error: base 128 integer too large")
 			return
 		}
 		ret <<= 7
@@ -522,7 +522,7 @@ func parseBase128Int(bytes []byte, initOffset int) (ret, offset int, err error) 
 			return
 		}
 	}
-	err = fmt.Errorf("syntax error: truncated base 128 integer")
+	err = errors.New("syntax error: truncated base 128 integer")
 	return
 }
 
@@ -632,7 +632,7 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 		}
 		i, err := parseInt(data[cursor:length])
 		if err != nil {
-			return nil, 0, fmt.Errorf("unable to parse raw INTEGER: %x err: %v", data, err)
+			return nil, 0, fmt.Errorf("unable to parse raw INTEGER: %x err: %w", data, err)
 		}
 		return i, length, nil
 	case OctetString:
@@ -672,7 +672,7 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 		}
 		ret, err := parseUint(data[cursor:length])
 		if err != nil {
-			return nil, 0, fmt.Errorf("error in parseUint: %s", err)
+			return nil, 0, fmt.Errorf("error in parseUint: %w", err)
 		}
 		return ret, length, nil
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -225,7 +225,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 		outBuf, err = packetOut.marshalMsg()
 		if err != nil {
 			// Don't retry - not going to get any better!
-			err = fmt.Errorf("marshal: %v", err)
+			err = fmt.Errorf("marshal: %w", err)
 			break
 		}
 
@@ -393,7 +393,7 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 			var buf = make([]byte, 8192)
 			runtime.Stack(buf, true)
 
-			err = fmt.Errorf("recover: %v\nStack:%v", e, string(buf))
+			err = fmt.Errorf("recover: %v Stack:%v", e, string(buf))
 		}
 	}()
 
@@ -553,9 +553,9 @@ func (packet *SnmpPacket) marshalSNMPV1TrapHeader() ([]byte, error) {
 	buf.Write(specificTrapBytes)
 
 	// marshal timeTicks
-	timeTickBytes, e := marshalUint32(uint32(packet.Timestamp))
-	if e != nil {
-		return nil, fmt.Errorf("unable to Timestamp: %s", e.Error())
+	timeTickBytes, err := marshalUint32(uint32(packet.Timestamp))
+	if err != nil {
+		return nil, fmt.Errorf("unable to Timestamp: %w", err)
 	}
 	buf.Write([]byte{byte(TimeTicks), byte(len(timeTickBytes))})
 	buf.Write(timeTickBytes)
@@ -1239,7 +1239,7 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		// Parse Value
 		v, err := x.decodeValue(packet[cursor:], "value")
 		if err != nil {
-			return fmt.Errorf("error decoding value: %v", err)
+			return fmt.Errorf("error decoding value: %w", err)
 		}
 
 		valueLength, _ := parseLength(packet[cursor:])

--- a/trap.go
+++ b/trap.go
@@ -239,13 +239,13 @@ func (t *TrapListener) listenUDP(addr string) error {
 					// determine), so it's left to future implementations.
 					ob, err := traps.marshalMsg()
 					if err != nil {
-						return fmt.Errorf("error marshaling INFORM response: %v", err)
+						return fmt.Errorf("error marshaling INFORM response: %w", err)
 					}
 
 					// Send the return packet back.
 					count, err := t.conn.WriteTo(ob, remote)
 					if err != nil {
-						return fmt.Errorf("error sending INFORM response: %v", err)
+						return fmt.Errorf("error sending INFORM response: %w", err)
 					}
 
 					// This isn't fatal, but should be logged.

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -730,7 +730,7 @@ func (sp *UsmSecurityParameters) decryptPacket(packet []byte, cursor int) ([]byt
 	_, cursorTmp := parseLength(packet[cursor:])
 	cursorTmp += cursor
 	if cursorTmp > len(packet) {
-		return nil, fmt.Errorf("error decrypting ScopedPDU: truncated packet")
+		return nil, errors.New("error decrypting ScopedPDU: truncated packet")
 	}
 
 	switch sp.PrivacyProtocol {
@@ -751,7 +751,7 @@ func (sp *UsmSecurityParameters) decryptPacket(packet []byte, cursor int) ([]byt
 		packet = packet[:cursor+len(plaintext)]
 	default:
 		if len(packet[cursorTmp:])%des.BlockSize != 0 {
-			return nil, fmt.Errorf("error decrypting ScopedPDU: not multiple of des block size")
+			return nil, errors.New("error decrypting ScopedPDU: not multiple of des block size")
 		}
 		preiv := sp.PrivacyKey[8:]
 		var iv [8]byte
@@ -831,12 +831,12 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	var err error
 
 	if PDUType(packet[cursor]) != Sequence {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model parameters")
+		return 0, errors.New("error parsing SNMPV3 User Security Model parameters")
 	}
 	_, cursorTmp := parseLength(packet[cursor:])
 	cursor += cursorTmp
 	if cursorTmp > len(packet) {
-		return 0, fmt.Errorf("error parsing SNMPV3 User Security Model parameters: truncated packet")
+		return 0, errors.New("error parsing SNMPV3 User Security Model parameters: truncated packet")
 	}
 
 	rawMsgAuthoritativeEngineID, count, err := parseRawField(sp.Logger, packet[cursor:], "msgAuthoritativeEngineID")


### PR DESCRIPTION
* Delete commented out code.
* Use `errors.New()` for fixed errors.
* Use `%w` for wrapping errors.
* Remove newlines from errors messages.

Signed-off-by: Ben Kochie <superq@gmail.com>