### PR TITLE
Improved perfomance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ NOTE: This release changes the Logger interface. The loggingEnabled variable has
 * [BUGFIX] marshal.go: improve packet validation and error handling #323
 * [BUGFIX] marshal.go: Fix on-error-continue flow in sendOneRequest #324
 * [CHANGE] New Logger interface has been implemented #329
+* [ENHANCEMENT]: helper.go: Improved OID marshaling with sub-identifier validation as per rfc2578 section-3.5 #321
 
 ## v1.31.0
 

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -30,6 +30,10 @@ const (
 	// Base OID for MIB-2 defined SNMP variables
 	baseOid = ".1.3.6.1.2.1"
 
+	// Max oid sub-identifier value
+	// https://tools.ietf.org/html/rfc2578#section-7.1.3
+	MaxObjectSubIdentifierValue = 4294967295
+
 	// Java SNMP uses 50, snmp-net uses 10
 	defaultMaxRepetitions = 50
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -15,30 +15,45 @@ import (
 
 // https://www.scadacore.com/tools/programming-calculators/online-hex-converter/ is useful
 
-func TestOidToString(t *testing.T) {
-	oid := []int{1, 2, 3, 4, 5}
-	expected := ".1.2.3.4.5"
-	result := oidToString(oid)
+func TestParseObjectIdentifier(t *testing.T) {
+	oid := []byte{43, 6, 1, 2, 1, 31, 1, 1, 1, 10, 143, 255, 255, 255, 127}
+	expected := ".1.3.6.1.2.1.31.1.1.1.10.4294967295"
 
-	if result != expected {
-		t.Errorf("oidToString(%v) = %s, want %s", oid, result, expected)
+	buf, err := parseObjectIdentifier(oid)
+	if err != nil {
+		t.Errorf("parseObjectIdentifier(%v) want %s, error: %v", oid, expected, err)
+	}
+	result := string(buf)
+
+	if string(result) != expected {
+		t.Errorf("parseObjectIdentifier(%v) = %s, want %s", oid, result, expected)
 	}
 }
 
-func TestWithAnotherOid(t *testing.T) {
-	oid := []int{4, 3, 2, 1, 3}
-	expected := ".4.3.2.1.3"
-	result := oidToString(oid)
-
-	if result != expected {
-		t.Errorf("oidToString(%v) = %s, want %s", oid, result, expected)
+func TestParseObjectIdentifierWithOtherOid(t *testing.T) {
+	oid := []byte{43, 6, 3, 30, 11, 1, 10}
+	expected := ".1.3.6.3.30.11.1.10"
+	buf, err := parseObjectIdentifier(oid)
+	if err != nil {
+		t.Errorf("parseObjectIdentifier(%v) want %s, error: %v", oid, expected, err)
+	}
+	result := string(buf)
+	if string(result) != expected {
+		t.Errorf("parseObjectIdentifier(%v) = %s, want %s", oid, result, expected)
 	}
 }
 
-func BenchmarkOidToString(b *testing.B) {
-	oid := []int{1, 2, 3, 4, 5}
+func BenchmarkParseObjectIdentifier(b *testing.B) {
+	oid := []byte{43, 6, 3, 30, 11, 1, 10}
 	for i := 0; i < b.N; i++ {
-		oidToString(oid)
+		parseObjectIdentifier(oid)
+	}
+}
+
+func BenchmarkMarshalObjectIdentifier(b *testing.B) {
+	oid := ".1.3.6.3.30.11.1.10"
+	for i := 0; i < b.N; i++ {
+		marshalObjectIdentifier(oid)
 	}
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -519,7 +519,7 @@ func (packet *SnmpPacket) marshalSNMPV1TrapHeader() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	// marshal OID
-	oidBytes, err := marshalOID(packet.Enterprise)
+	oidBytes, err := marshalObjectIdentifier(packet.Enterprise)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal OID: %w", err)
 	}
@@ -690,7 +690,7 @@ func (packet *SnmpPacket) marshalVBL() ([]byte, error) {
 
 // marshal a varbind
 func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
-	oid, err := marshalOID(pdu.Name)
+	oid, err := marshalObjectIdentifier(pdu.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +814,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 		tmpBuf.Write([]byte{byte(ObjectIdentifier), byte(len(oid))})
 		tmpBuf.Write(oid)
 		value := pdu.Value.(string)
-		oidBytes, err := marshalOID(value)
+		oidBytes, err := marshalObjectIdentifier(value)
 		if err != nil {
 			return nil, fmt.Errorf("error marshalling ObjectIdentifier: %w", err)
 		}
@@ -1110,13 +1110,14 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	if err != nil {
 		return fmt.Errorf("error parsing SNMP packet error: %w", err)
 	}
+
 	cursor += count
 	if cursor > len(packet) {
 		return fmt.Errorf("error parsing SNMP packet, packet length %d cursor %d", len(packet), cursor)
 	}
 
-	if Enterprise, ok := rawEnterprise.([]int); ok {
-		response.Enterprise = oidToString(Enterprise)
+	if Enterprise, ok := rawEnterprise.(string); ok {
+		response.Enterprise = Enterprise
 		x.Logger.Printf("Enterprise: %+v", Enterprise)
 	}
 
@@ -1228,20 +1229,15 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		if err != nil {
 			return fmt.Errorf("error parsing OID Value: %w", err)
 		}
-
 		cursor += oidLength
 		if cursor > len(packet) {
 			return fmt.Errorf("error parsing OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
 		}
-
-		var oid []int
-		var ok bool
-		if oid, ok = rawOid.([]int); !ok {
-			return fmt.Errorf("unable to type assert rawOid |%v| to []int", rawOid)
+		oid, ok := rawOid.(string)
+		if !ok {
+			return fmt.Errorf("unable to type assert rawOid |%v| to string", rawOid)
 		}
-		oidStr := oidToString(oid)
-		x.Logger.Printf("OID: %s", oidStr)
-
+		x.Logger.Printf("OID: %s", oid)
 		// Parse Value
 		v, err := x.decodeValue(packet[cursor:], "value")
 		if err != nil {
@@ -1254,7 +1250,7 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("error decoding OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
 		}
 
-		response.Variables = append(response.Variables, SnmpPDU{oidStr, v.Type, v.Value})
+		response.Variables = append(response.Variables, SnmpPDU{oid, v.Type, v.Value})
 	}
 	return nil
 }


### PR DESCRIPTION
The marshalOID () and oidToString () functions use the string functions Trim, Split, Join, which work internally with an array of strings. Also, to convert the oid string to an array of numbers and in the opposite direction, an additional array is created inside both marshalOID () and oidToString (), which causes at least twice the load on the GC.
In my case, with parallel polling of 100k + devices, this change in these functions improved performance and CPU load by 10% -15%. The average CPU load dropped from 80% to 65% after. In addition, the total polling time has noticeably decreased.

The second patch (reverted due to broken ci check) concerns the logging function logger.Printf(). Even with logging disabled, the Printf() system call is still called, which, according to pprof, also consumes a significant portion of the CPU time.
I don't know what to do in this case, so I just commented them out in problem areas. Logically, the logPrintf () function should be called here, but in these cases it is not available for call. 