### PR TITLE
marshal.go: improve packet validation and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 NOTE:
 
+* [BUGFIX] marshal.go: improve packet validation and error handling #323
+
 ## v1.31.0
 
 * [BUGFIX] Add validation to prevent calling updatePktSecurityParameters with non v3 packet #251 #314


### PR DESCRIPTION
* marshal.go: Add error handling to decryptPacket call in sendOneRequest()
* marshal.go: Add empty/nil packet validation to unmarshalPayload()

Fixes #311

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>