### PR TITLE
marshal.go: Fix on-error-continue flow in sendOneRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 NOTE:
 
 * [BUGFIX] marshal.go: improve packet validation and error handling #323
+* [BUGFIX] marshal.go: Fix on-error-continue flow in sendOneRequest #324
 
 ## v1.31.0
 

--- a/marshal.go
+++ b/marshal.go
@@ -289,7 +289,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			cursor, err = x.unmarshalHeader(resp, result)
 			if err != nil {
 				x.logPrintf("ERROR on unmarshall header: %s", err)
-				continue
+				break
 			}
 
 			if x.Version == Version3 {
@@ -314,11 +314,11 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			err = x.unmarshalPayload(resp, cursor, result)
 			if err != nil {
 				x.logPrintf("ERROR on UnmarshalPayload on v3: %s", err)
-				continue
+				break
 			}
 			if result.Error == NoError && len(result.Variables) < 1 {
 				x.logPrintf("ERROR on UnmarshalPayload on v3: Empty result")
-				continue
+				break
 			}
 
 			// While Report PDU was defined by RFC 1905 as part of SNMPv2, it was never


### PR DESCRIPTION
* marshal.go: Fix erroneous on-error continue flow in ``sendOneRequest()`` that caused time-outs after a marshal error.

Fixes #246 

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>