### PR TITLE
helper.go: parseRawField fix nil logger panic

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -623,7 +623,9 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 	if len(data) == 0 {
 		return nil, 0, fmt.Errorf("empty data passed to parseRawField")
 	}
-	logger.Printf("parseRawField: %s", msg)
+	if logger != nil {
+		logger.Printf("parseRawField: %s", msg)
+	}
 	switch Asn1BER(data[0]) {
 	case Integer:
 		length, cursor := parseLength(data)


### PR DESCRIPTION
helper.go: Fix panic in parseRawField when logger is nil

Fixes #327

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>