### PR TITLE
Fix snmpv3 trap

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -581,6 +581,9 @@ func parseLength(bytes []byte) (length int, cursor int) {
 		cursor += 2
 	default:
 		numOctets := int(bytes[1]) & 127
+		if len(bytes) < numOctets {
+			return 0, 0
+		}
 		for i := 0; i < numOctets; i++ {
 			length <<= 8
 			length += int(bytes[2+i])

--- a/helper.go
+++ b/helper.go
@@ -581,9 +581,6 @@ func parseLength(bytes []byte) (length int, cursor int) {
 		cursor += 2
 	default:
 		numOctets := int(bytes[1]) & 127
-		if len(bytes) < numOctets {
-			return 0, 0
-		}
 		for i := 0; i < numOctets; i++ {
 			length <<= 8
 			length += int(bytes[2+i])

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -621,44 +621,48 @@ func (sp *UsmSecurityParameters) discoveryRequired() *SnmpPacket {
 	return nil
 }
 
-func (sp *UsmSecurityParameters) calcPacketDigest(packet []byte) []byte {
+func (sp *UsmSecurityParameters) calcPacketDigest(packet []byte) ([]byte, error) {
 	return calcPacketDigest(packet, sp)
 }
 
 // calcPacketDigest calculate authenticate digest for incoming messages (TRAP or
 // INFORM).
 // Support MD5, SHA1, SHA224, SHA256, SHA384, SHA512 protocols
-func calcPacketDigest(packetBytes []byte, secParams *UsmSecurityParameters) []byte {
+func calcPacketDigest(packetBytes []byte, secParams *UsmSecurityParameters) ([]byte, error) {
 	var digest []byte
+	var err error
 
 	switch secParams.AuthenticationProtocol {
 	case MD5, SHA:
-		digest = digestRFC3414(
+		digest, err = digestRFC3414(
 			secParams.AuthenticationProtocol,
 			packetBytes,
 			secParams.SecretKey)
 	case SHA224, SHA256, SHA384, SHA512:
-		digest = digestRFC7860(
+		digest, err = digestRFC7860(
 			secParams.AuthenticationProtocol,
 			packetBytes,
 			secParams.SecretKey)
 	}
 
-	return digest
+	return digest, err
 }
 
 // digestRFC7860 calculate digest for incoming messages using HMAC-SHA2 protcols
 // according to RFC7860 4.2.2
-func digestRFC7860(h SnmpV3AuthProtocol, packet []byte, authKey []byte) []byte {
+func digestRFC7860(h SnmpV3AuthProtocol, packet []byte, authKey []byte) ([]byte, error) {
 	mac := hmac.New(h.HashType().New, authKey)
-	_, _ = mac.Write(packet)
+	_, err := mac.Write(packet)
+	if err != nil {
+		return []byte{}, err
+	}
 	msgDigest := mac.Sum(nil)
-	return msgDigest
+	return msgDigest, nil
 }
 
 // digestRFC3414 calculate digest for incoming messages using MD5 or SHA1
 // according to RFC3414 6.3.2 and 7.3.2
-func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) []byte {
+func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) ([]byte, error) {
 	var extkey [64]byte
 	var err error
 	var k1, k2 [64]byte
@@ -682,31 +686,37 @@ func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) []byte {
 
 	_, err = h1.Write(k1[:])
 	if err != nil {
-		return []byte{}
+		return []byte{}, err
 	}
 
 	_, err = h1.Write(packet)
 	if err != nil {
-		return []byte{}
+		return []byte{}, err
 	}
 
 	d1 := h1.Sum(nil)
 
 	_, err = h2.Write(k2[:])
 	if err != nil {
-		return []byte{}
+		return []byte{}, err
 	}
 
 	_, err = h2.Write(d1)
 	if err != nil {
-		return []byte{}
+		return []byte{}, err
 	}
 
-	return h2.Sum(nil)[:12]
+	return h2.Sum(nil)[:12], nil
 }
 
 func (sp *UsmSecurityParameters) authenticate(packet []byte) error {
-	msgDigest := sp.calcPacketDigest(packet)
+	var msgDigest []byte
+	var err error
+
+	if msgDigest, err = sp.calcPacketDigest(packet); err != nil {
+		return err
+	}
+
 	idx := bytes.Index(packet, macVarbinds[sp.AuthenticationProtocol])
 
 	if idx < 0 {
@@ -719,6 +729,7 @@ func (sp *UsmSecurityParameters) authenticate(packet []byte) error {
 
 // determine whether a message is authentic
 func (sp *UsmSecurityParameters) isAuthentic(packetBytes []byte, packet *SnmpPacket) (bool, error) {
+	var msgDigest []byte
 	var packetSecParams *UsmSecurityParameters
 	var err error
 
@@ -726,7 +737,9 @@ func (sp *UsmSecurityParameters) isAuthentic(packetBytes []byte, packet *SnmpPac
 		return false, err
 	}
 	// TODO: investigate call chain to determine if this is really the best spot for this
-	msgDigest := calcPacketDigest(packetBytes, packetSecParams)
+	if msgDigest, err = calcPacketDigest(packetBytes, packetSecParams); err != nil {
+		return false, err
+	}
 
 	for k, v := range []byte(packetSecParams.AuthenticationParameters) {
 		if msgDigest[k] != v {

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -17,7 +17,9 @@ import (
 	"crypto/hmac"
 	"crypto/md5" //nolint:gosec
 	crand "crypto/rand"
-	"crypto/sha1" //nolint:gosec
+	"crypto/sha1"     //nolint:gosec
+	_ "crypto/sha256" //nolint:gosec resolve requested hash function #4,#5is unavailable
+	_ "crypto/sha512" //nolint:gosec resolve requested hash function #7 is unavailable
 	"encoding/binary"
 	"encoding/hex"
 	"errors"

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -18,8 +18,6 @@ import (
 	"crypto/md5" //nolint:gosec
 	crand "crypto/rand"
 	"crypto/sha1" //nolint:gosec
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -668,11 +666,11 @@ func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) []byte {
 
 	switch h {
 	case MD5:
-		h1 = md5.New()
-		h2 = md5.New()
+		h1 = md5.New() //nolint:gosec
+		h2 = md5.New() //nolint:gosec
 	case SHA:
-		h1 = sha1.New()
-		h2 = sha1.New()
+		h1 = sha1.New() //nolint:gosec
+		h2 = sha1.New() //nolint:gosec
 	}
 
 	for i := 0; i < 64; i++ {

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -15,10 +15,10 @@ import (
 	"crypto/cipher"
 	"crypto/des" //nolint:gosec
 	"crypto/hmac"
-	"crypto/md5"
+	"crypto/md5"   //nolint:gosec
 	_ "crypto/md5" //nolint:gosec
 	crand "crypto/rand"
-	"crypto/sha1"
+	"crypto/sha1"   //nolint:gosec
 	_ "crypto/sha1" //nolint:gosec
 	_ "crypto/sha256"
 	_ "crypto/sha512"
@@ -624,7 +624,6 @@ func (sp *UsmSecurityParameters) discoveryRequired() *SnmpPacket {
 }
 
 func (sp *UsmSecurityParameters) calcPacketDigest(packet []byte) []byte {
-
 	return calcPacketDigest(packet, sp)
 }
 func calcPacketDigest(packetBytes []byte, secParams *UsmSecurityParameters) []byte {
@@ -687,8 +686,8 @@ func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) []byte {
 	}
 
 	return h2.Sum(nil)[:12]
-
 }
+
 func (sp *UsmSecurityParameters) authenticate(packet []byte) error {
 	msgDigest := sp.calcPacketDigest(packet)
 	idx := bytes.Index(packet, macVarbinds[sp.AuthenticationProtocol])

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -18,8 +18,8 @@ import (
 	"crypto/md5" //nolint:gosec
 	crand "crypto/rand"
 	"crypto/sha1"     //nolint:gosec
-	_ "crypto/sha256" //nolint:gosec resolve requested hash function #4,#5is unavailable
-	_ "crypto/sha512" //nolint:gosec resolve requested hash function #7 is unavailable
+	_ "crypto/sha256" // Register hash function #4 (SHA224), #5 (SHA256)
+	_ "crypto/sha512" // Register hash function #6 (SHA384), #7 (SHA512)
 	"encoding/binary"
 	"encoding/hex"
 	"errors"


### PR DESCRIPTION
This fix correct SNMPv3 implementation for traps according to :

- RFC3414 for MD5 and SHA1
- RFC7860 for SHA2 (SHA-224, SHA-256, SHA-384, SHA-512)

If a trap arrive and cannot be decoded, there could be an "out of range index". This fix silently fail instead of a panic.

More details in #284