### PR TITLE
Release v1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
 ## unreleased
 
+NOTE:
+
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX]
 
-## Unreleased
+## v1.32.0
 
 NOTE: This release changes the Logger interface. The loggingEnabled variable has been deprecated.
 
 * [BUGFIX] marshal.go: improve packet validation and error handling #323
 * [BUGFIX] marshal.go: Fix on-error-continue flow in sendOneRequest #324
+* [BUGFIX] Fix SNMPv3 trap authentication #332
 * [CHANGE] New Logger interface has been implemented #329
-* [ENHANCEMENT]: helper.go: Improved OID marshaling with sub-identifier validation as per rfc2578 section-3.5 #321
+* [ENHANCEMENT] helper.go: Improved OID marshaling with sub-identifier validation as per rfc2578 section-3.5 #321
+* [ENHANCEMENT] Add rfc3412 report errors #333
 
 ## v1.31.0
 


### PR DESCRIPTION
Release v1.32.0

NOTE: This release changes the Logger interface. The loggingEnabled variable has been deprecated.

* [BUGFIX] marshal.go: improve packet validation and error handling #323
* [BUGFIX] marshal.go: Fix on-error-continue flow in sendOneRequest #324
* [BUGFIX] Fix SNMPv3 trap authentication #332
* [CHANGE] New Logger interface has been implemented #329
* [ENHANCEMENT] helper.go: Improved OID marshaling with sub-identifier validation as per rfc2578 section-3.5 #321
* [ENHANCEMENT] Add rfc3412 report errors #333

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>