### PR TITLE
helper.go: Improved decodeValue() function

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1251,8 +1251,8 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		}
 		x.Logger.Printf("OID: %s", oid)
 		// Parse Value
-		v, err := x.decodeValue(packet[cursor:], "value")
-		if err != nil {
+		var decodedVal variable
+		if err := x.decodeValue(packet[cursor:], &decodedVal); err != nil {
 			return fmt.Errorf("error decoding value: %w", err)
 		}
 
@@ -1262,7 +1262,7 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("error decoding OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
 		}
 
-		response.Variables = append(response.Variables, SnmpPDU{oid, v.Type, v.Value})
+		response.Variables = append(response.Variables, SnmpPDU{oid, decodedVal.Type, decodedVal.Value})
 	}
 	return nil
 }


### PR DESCRIPTION
In the decodeValue () function, the msg parameter is always "value". It doesn't make any sense.

Also in this function, the retVal variable can be declared before the function call and passed as a parameter. It will be cheaper than creating it on the heap every time inside decodeValue (). Because:

response.Variables = append(response.Variables, SnmpPDU{oid, decodedVal.Type, decodedVal.Value})

In this case, it is safe. The SnmpPDU is passed the field values, not the structure itself.

It also gives small winnings in both Bytes/op and allocs/op