### PR TITLE
Allow binding a socket to a specific local address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ NOTE:
 * [ENHANCEMENT]
 * [BUGFIX]
 
+## Unreleased
+
+* [FEATURE] Add LocalAddr setting to bind source address of SNMP queries #342
+
 ## v1.32.0
 
 NOTE: This release changes the Logger interface. The loggingEnabled variable has been deprecated.

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -9,6 +9,7 @@
 // Ensure "gosnmp-test-host" is defined in your hosts file, and points to your
 // generic test system.
 
+//go:build all || end2end
 // +build all end2end
 
 package gosnmp

--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -7,6 +7,7 @@
 // IMPORTANT: If you're modifying _any_ existing code in this file, you
 // should be asking yourself about API compatibility!
 
+//go:build all || api
 // +build all api
 
 package gosnmp_test // force external view

--- a/helper_test.go
+++ b/helper_test.go
@@ -2,6 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build all || helper
 // +build all helper
 
 package gosnmp

--- a/logger.go
+++ b/logger.go
@@ -1,3 +1,4 @@
+//go:build gosnmp_nodebug
 // +build gosnmp_nodebug
 
 // When building, specify the gosnmp_nodebug tag and logging will be completely disabled

--- a/logger_debug.go
+++ b/logger_debug.go
@@ -1,3 +1,4 @@
+//go:build !gosnmp_nodebug
 // +build !gosnmp_nodebug
 
 package gosnmp

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2,6 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build all || marshal
 // +build all marshal
 
 package gosnmp
@@ -1514,9 +1515,9 @@ func TestUnconnectedSocket_success(t *testing.T) {
 }
 
 func withUnconnectedSocket(t *testing.T, enable bool) {
-	srvr, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	srvr, err := net.ListenUDP("udp", &net.UDPAddr{})
 	if err != nil {
-		t.Fatalf("udp4 error listening: %s", err)
+		t.Fatalf("udp error listening: %s", err)
 	}
 	defer srvr.Close()
 
@@ -1527,10 +1528,12 @@ func withUnconnectedSocket(t *testing.T, enable bool) {
 		Timeout:                 time.Millisecond * 100,
 		Retries:                 2,
 		UseUnconnectedUDPSocket: enable,
+		LocalAddr:               "0.0.0.0:",
 	}
 	if err := x.Connect(); err != nil {
 		t.Fatalf("error connecting: %s", err)
 	}
+    defer x.Conn.Close()
 
 	go func() {
 		buf := make([]byte, 256)
@@ -1566,7 +1569,7 @@ func withUnconnectedSocket(t *testing.T, enable bool) {
 			}
 			// Temporary socket will use different source port, it's enough to break
 			// connected socket reply filters.
-			nsock, err := net.ListenUDP("udp4", nil)
+			nsock, err := net.ListenUDP("udp", nil)
 			if err != nil {
 				t.Errorf("can't create temporary reply socket: %v", err)
 			}

--- a/misc_test.go
+++ b/misc_test.go
@@ -2,6 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build all || misc
 // +build all misc
 
 package gosnmp

--- a/trap_test.go
+++ b/trap_test.go
@@ -2,6 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
+//go:build all || trap
 // +build all trap
 
 package gosnmp


### PR DESCRIPTION
Closes: https://github.com/gosnmp/gosnmp/issues/339

Allow socket binding to a specific local address. Only works for UseUnconnectedUDPSocket = true.
To set the listening address, a new Listen variable has been added with a default value of ":0". This value matches the previously used behavior when using UseUnconnectedUDPSocket = true (bind to 0.0.0.0 with random port)
For example:
```
gosnmp.Default.Listen = "1.2.3.4:161"
```