### PR TITLE
Avoid an OOB read

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -571,6 +571,10 @@ func parseLength(bytes []byte) (length int, cursor int) {
 		numOctets := int(bytes[1]) & 127
 		for i := 0; i < numOctets; i++ {
 			length <<= 8
+			if len(bytes) < 2+i+1 {
+				// Invalid data, return something safe-ish
+				return len(bytes), len(bytes)
+			}
 			length += int(bytes[2+i])
 		}
 		length += 2 + numOctets


### PR DESCRIPTION
This patch prevents a corrupted response from leading to a panic in the decoder. A better patch would involve redoing parseLength to return an error and updating all callers, but this would be extensive, and this change results in the right behavior (the packet fails to decode, instead of triggering a panic).