### PR TITLE
remove: func uint64ToBigInt(uint64) *big.Int

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -625,6 +625,7 @@ func Partition(currentPosition, partitionSize, sliceLength int) bool {
 // return int32, uint32, and uint64.
 func ToBigInt(value interface{}) *big.Int {
 	var val int64
+
 	switch value := value.(type) { // shadow
 	case int:
 		val = int64(value)
@@ -644,16 +645,17 @@ func ToBigInt(value interface{}) *big.Int {
 		val = int64(value)
 	case uint32:
 		val = int64(value)
-	case uint64:
-		return (uint64ToBigInt(value))
+	case uint64: // beware: int64(MaxUint64) overflow, handle different
+		return new(big.Int).SetUint64(value)
 	case string:
 		// for testing and other apps - numbers may appear as strings
 		var err error
 		if val, err = strconv.ParseInt(value, 10, 64); err != nil {
-			return new(big.Int)
+			val = 0
 		}
 	default:
-		return new(big.Int)
+		val = 0
 	}
+
 	return big.NewInt(val)
 }

--- a/helper.go
+++ b/helper.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"log"
 	"math"
-	"math/big"
 	"net"
 	"os"
 	"strconv"
@@ -724,28 +723,6 @@ func parseFloat64(bytes []byte) (ret float64, err error) {
 	}
 	ret = math.Float64frombits(binary.BigEndian.Uint64(bytes))
 	return
-}
-
-// Issue 4389: math/big: add SetUint64 and Uint64 functions to *Int
-//
-// uint64ToBigInt copied from: http://github.com/cznic/mathutil/blob/master/mathutil.go#L341
-//
-// replace with Uint64ToBigInt or equivalent when using Go 1.1
-
-//nolint:gochecknoglobals
-var uint64ToBigIntDelta big.Int
-
-func init() {
-	uint64ToBigIntDelta.SetBit(&uint64ToBigIntDelta, 63, 1)
-}
-
-func uint64ToBigInt(n uint64) *big.Int {
-	if n <= math.MaxInt64 {
-		return big.NewInt(int64(n))
-	}
-
-	y := big.NewInt(int64(n - uint64(math.MaxInt64) - 1))
-	return y.Add(y, &uint64ToBigIntDelta)
 }
 
 // -- Bit String ---------------------------------------------------------------

--- a/misc_test.go
+++ b/misc_test.go
@@ -12,13 +12,13 @@ import (
 	_ "crypto/md5"
 	_ "crypto/sha1"
 	"errors"
+	"math"
+	"math/big"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// Tests in alphabetical order of function being tested
 
 // -----------------------------------------------------------------------------
 
@@ -76,6 +76,44 @@ func TestPartition(t *testing.T) {
 		ok := Partition(test.currentPosition, test.partitionSize, test.sliceLength)
 		if ok != test.ok {
 			t.Errorf("#%d: Bad result: %v (expected %v)", i, ok, test.ok)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+
+var testsToBigInt = []struct {
+	in       interface{}
+	expected *big.Int
+}{
+	{int8(-42), big.NewInt(-42)},
+	{int16(42), big.NewInt(42)},
+	{int32(-42), big.NewInt(-42)},
+	{int64(42), big.NewInt(42)},
+
+	{uint8(42), big.NewInt(42)},
+	{uint16(42), big.NewInt(42)},
+	{uint32(42), big.NewInt(42)},
+	{uint64(42), big.NewInt(42)},
+
+	// edge case, max uint64
+	{uint64(math.MaxUint64), new(big.Int).SetUint64(math.MaxUint64)},
+
+	// string: valid number
+	{"-123456789", big.NewInt(-123456789)},
+
+	// string: invalid number
+	{"foo", new(big.Int)},
+
+	// unhandled type
+	{struct{}{}, new(big.Int)},
+}
+
+func TestToBigInt(t *testing.T) {
+	for i, test := range testsToBigInt {
+		result := ToBigInt(test.in)
+		if result.Cmp(test.expected) != 0 {
+			t.Errorf("#%d, %T: got %v expected %v", i, test.in, result, test.expected)
 		}
 	}
 }
@@ -188,3 +226,5 @@ func parseBitString(bytes []byte) (ret BitStringValue, err error) {
 	ret.Bytes = bytes[1:]
 	return
 }
+
+// ---------------------------------------------------------------------


### PR DESCRIPTION
This is no longer needed since Go1.1