### PR TITLE
helper.go: add error handling to parseLength

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -28,6 +28,11 @@ type variable struct {
 	Value interface{}
 }
 
+// helper error modes
+var (
+	ErrInvalidPacketLength = errors.New("invalid packet length")
+)
+
 // -- helper functions (mostly) in alphabetical order --------------------------
 
 // Check makes checking errors easy, so they actually get a minimal check
@@ -585,7 +590,6 @@ func parseInt(bytes []byte) (int, error) {
 //   octets give the length, base 256, most significant digit first.
 func parseLength(bytes []byte) (int, int, error) {
 	var cursor, length int
-	var ErrInvalidPacketLength = errors.New("invalid packet length")
 	switch {
 	case len(bytes) <= 2:
 		// handle null octet strings ie "0x04 0x00"

--- a/helper.go
+++ b/helper.go
@@ -583,7 +583,8 @@ func parseInt(bytes []byte) (int, error) {
 // * Long form. Two to 127 octets. Bit 8 of first octet has value "1" and bits
 //   7-1 give the number of additional length octets. Second and following
 //   octets give the length, base 256, most significant digit first.
-func parseLength(bytes []byte) (length int, cursor int, err error) {
+func parseLength(bytes []byte) (int, int, error) {
+	var cursor, length int
 	var ErrInvalidPacketLength = errors.New("invalid packet length")
 	switch {
 	case len(bytes) <= 2:

--- a/helper.go
+++ b/helper.go
@@ -69,23 +69,30 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case Integer:
 		// 0x02. signed
 		x.Logger.Print("decodeValue: type is Integer")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
+		// check for truncated packets
 		if length > len(data) {
 			return fmt.Errorf("bytes: % x err: truncated (data %d length %d)", data, len(data), length)
 		}
 
 		var ret int
-		var err2 error
-		if ret, err2 = parseInt(data[cursor:length]); err2 != nil {
-			x.Logger.Printf("%v:", err2)
-			return fmt.Errorf("bytes: % x err: %w", data, err2)
+		if ret, err = parseInt(data[cursor:length]); err != nil {
+			x.Logger.Printf("%v:", err)
+			return fmt.Errorf("bytes: % x err: %w", data, err)
 		}
 		retVal.Type = Integer
 		retVal.Value = ret
 	case OctetString:
 		// 0x04
 		x.Logger.Print("decodeValue: type is OctetString")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
+		// check for truncated packet and throw an error
 		if length > len(data) {
 			return fmt.Errorf("bytes: % x err: truncated (data %d length %d)", data, len(data), length)
 		}
@@ -100,9 +107,9 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case ObjectIdentifier:
 		// 0x06
 		x.Logger.Print("decodeValue: type is ObjectIdentifier")
-		rawOid, _, err2 := parseRawField(x.Logger, data, "OID")
-		if err2 != nil {
-			return fmt.Errorf("error parsing OID Value: %w", err2)
+		rawOid, _, err := parseRawField(x.Logger, data, "OID")
+		if err != nil {
+			return fmt.Errorf("error parsing OID Value: %w", err)
 		}
 		oid, ok := rawOid.(string)
 		if !ok {
@@ -140,14 +147,17 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case Counter32:
 		// 0x41. unsigned
 		x.Logger.Print("decodeValue: type is Counter32")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for Counter32 %x (data %d length %d)", data, len(data), length)
 		}
 
-		ret, err2 := parseUint(data[cursor:length])
-		if err2 != nil {
-			x.Logger.Printf("decodeValue: err is %v", err2)
+		ret, err := parseUint(data[cursor:length])
+		if err != nil {
+			x.Logger.Printf("decodeValue: err is %v", err)
 			break
 		}
 		retVal.Type = Counter32
@@ -155,14 +165,17 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case Gauge32:
 		// 0x42. unsigned
 		x.Logger.Print("decodeValue: type is Gauge32")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for Gauge32 %x (data %d length %d)", data, len(data), length)
 		}
 
-		ret, err2 := parseUint(data[cursor:length])
-		if err2 != nil {
-			x.Logger.Printf("decodeValue: err is %v", err2)
+		ret, err := parseUint(data[cursor:length])
+		if err != nil {
+			x.Logger.Printf("decodeValue: err is %v", err)
 			break
 		}
 		retVal.Type = Gauge32
@@ -170,14 +183,17 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case TimeTicks:
 		// 0x43
 		x.Logger.Print("decodeValue: type is TimeTicks")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for TimeTicks %x (data %d length %d)", data, len(data), length)
 		}
 
-		ret, err2 := parseUint32(data[cursor:length])
-		if err2 != nil {
-			x.Logger.Printf("decodeValue: err is %v", err2)
+		ret, err := parseUint32(data[cursor:length])
+		if err != nil {
+			x.Logger.Printf("decodeValue: err is %v", err)
 			break
 		}
 		retVal.Type = TimeTicks
@@ -185,7 +201,10 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case Opaque:
 		// 0x44
 		x.Logger.Print("decodeValue: type is Opaque")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for Opaque %x (data %d length %d)", data, len(data), length)
 		}
@@ -196,14 +215,17 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case Counter64:
 		// 0x46
 		x.Logger.Print("decodeValue: type is Counter64")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for Counter64 %x (data %d length %d)", data, len(data), length)
 		}
 
-		ret, err2 := parseUint64(data[cursor:length])
-		if err2 != nil {
-			x.Logger.Printf("decodeValue: err is %v", err2)
+		ret, err := parseUint64(data[cursor:length])
+		if err != nil {
+			x.Logger.Printf("decodeValue: err is %v", err)
 			break
 		}
 		retVal.Type = Counter64
@@ -211,12 +233,14 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case OpaqueFloat:
 		// 0x78
 		x.Logger.Print("decodeValue: type is OpaqueFloat")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for OpaqueFloat %x (data %d length %d)", data, len(data), length)
 		}
 
-		var err error
 		retVal.Type = OpaqueFloat
 		retVal.Value, err = parseFloat32(data[cursor:length])
 		if err != nil {
@@ -225,12 +249,14 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 	case OpaqueDouble:
 		// 0x79
 		x.Logger.Print("decodeValue: type is OpaqueDouble")
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return err
+		}
 		if length > len(data) {
 			return fmt.Errorf("not enough data for OpaqueDouble %x (data %d length %d)", data, len(data), length)
 		}
 
-		var err error
 		retVal.Type = OpaqueDouble
 		retVal.Value, err = parseFloat64(data[cursor:length])
 		if err != nil {
@@ -546,6 +572,7 @@ func parseInt(bytes []byte) (int, error) {
 }
 
 // parseLength parses and calculates an snmp packet length
+// and returns an error when invalid data is detected
 //
 // http://luca.ntop.org/Teaching/Appunti/asn1.html
 //
@@ -556,7 +583,8 @@ func parseInt(bytes []byte) (int, error) {
 // * Long form. Two to 127 octets. Bit 8 of first octet has value "1" and bits
 //   7-1 give the number of additional length octets. Second and following
 //   octets give the length, base 256, most significant digit first.
-func parseLength(bytes []byte) (length int, cursor int) {
+func parseLength(bytes []byte) (length int, cursor int, err error) {
+	var ErrInvalidPacketLength = errors.New("invalid packet length")
 	switch {
 	case len(bytes) <= 2:
 		// handle null octet strings ie "0x04 0x00"
@@ -571,15 +599,15 @@ func parseLength(bytes []byte) (length int, cursor int) {
 		for i := 0; i < numOctets; i++ {
 			length <<= 8
 			if len(bytes) < 2+i+1 {
-				// Invalid data, return something safe-ish
-				return len(bytes), len(bytes)
+				// Invalid data detected, return an error
+				return 0, 0, ErrInvalidPacketLength
 			}
 			length += int(bytes[2+i])
 		}
 		length += 2 + numOctets
 		cursor += 2 + numOctets
 	}
-	return length, cursor
+	return length, cursor, nil
 }
 
 // parseObjectIdentifier parses an OBJECT IDENTIFIER from the given bytes and
@@ -617,7 +645,10 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 	logger.Printf("parseRawField: %s", msg)
 	switch Asn1BER(data[0]) {
 	case Integer:
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return nil, 0, err
+		}
 		if length > len(data) {
 			return nil, 0, fmt.Errorf("not enough data for Integer (%d vs %d): %x", length, len(data), data)
 		}
@@ -627,20 +658,29 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 		}
 		return i, length, nil
 	case OctetString:
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return nil, 0, err
+		}
 		if length > len(data) {
 			return nil, 0, fmt.Errorf("not enough data for OctetString (%d vs %d): %x", length, len(data), data)
 		}
 		return string(data[cursor:length]), length, nil
 	case ObjectIdentifier:
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return nil, 0, err
+		}
 		if length > len(data) {
 			return nil, 0, fmt.Errorf("not enough data for OID (%d vs %d): %x", length, len(data), data)
 		}
 		oid, err := parseObjectIdentifier(data[cursor:length])
 		return oid, length, err
 	case IPAddress:
-		length, _ := parseLength(data)
+		length, _, err := parseLength(data)
+		if err != nil {
+			return nil, 0, err
+		}
 		if len(data) < 2 {
 			return nil, 0, fmt.Errorf("not enough data for ipv4 address: %x", data)
 		}
@@ -657,7 +697,10 @@ func parseRawField(logger Logger, data []byte, msg string) (interface{}, int, er
 			return nil, 0, fmt.Errorf("got ipaddress len %d, expected 4", data[1])
 		}
 	case TimeTicks:
-		length, cursor := parseLength(data)
+		length, cursor, err := parseLength(data)
+		if err != nil {
+			return nil, 0, err
+		}
 		if length > len(data) {
 			return nil, 0, fmt.Errorf("not enough data for TimeTicks (%d vs %d): %x", length, len(data), data)
 		}

--- a/marshal.go
+++ b/marshal.go
@@ -938,7 +938,10 @@ func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, erro
 		return 0, fmt.Errorf("invalid packet header")
 	}
 
-	length, cursor := parseLength(packet)
+	length, cursor, err := parseLength(packet)
+	if err != nil {
+		return 0, err
+	}
 	if len(packet) != length {
 		return 0, fmt.Errorf("error verifying packet sanity: Got %d Expected: %d", len(packet), length)
 	}
@@ -1024,7 +1027,10 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 	cursor := 0
 
-	getResponseLength, cursor := parseLength(packet)
+	getResponseLength, cursor, err := parseLength(packet)
+	if err != nil {
+		return err
+	}
 	if len(packet) != getResponseLength {
 		return fmt.Errorf("error verifying Response sanity: Got %d Expected: %d", len(packet), getResponseLength)
 	}
@@ -1111,7 +1117,10 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 	cursor := 0
 
-	getResponseLength, cursor := parseLength(packet)
+	getResponseLength, cursor, err := parseLength(packet)
+	if err != nil {
+		return err
+	}
 	if len(packet) != getResponseLength {
 		return fmt.Errorf("error verifying Response sanity: Got %d Expected: %d", len(packet), getResponseLength)
 	}
@@ -1209,7 +1218,10 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		return fmt.Errorf("expected a sequence when unmarshalling a VBL, got %x", packet[cursor])
 	}
 
-	vblLength, cursor = parseLength(packet)
+	vblLength, cursor, err := parseLength(packet)
+	if err != nil {
+		return err
+	}
 	if vblLength == 0 || vblLength > len(packet) {
 		return fmt.Errorf("truncated packet when unmarshalling a VBL, packet length %d cursor %d", len(packet), cursor)
 	}
@@ -1230,7 +1242,10 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("expected a sequence when unmarshalling a VB, got %x", packet[cursor])
 		}
 
-		_, cursorInc = parseLength(packet[cursor:])
+		_, cursorInc, err = parseLength(packet[cursor:])
+		if err != nil {
+			return err
+		}
 		cursor += cursorInc
 		if cursor > len(packet) {
 			return fmt.Errorf("error parsing OID Value: packet %d cursor %d", len(packet), cursor)
@@ -1252,11 +1267,14 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		x.Logger.Printf("OID: %s", oid)
 		// Parse Value
 		var decodedVal variable
-		if err := x.decodeValue(packet[cursor:], &decodedVal); err != nil {
+		if err = x.decodeValue(packet[cursor:], &decodedVal); err != nil {
 			return fmt.Errorf("error decoding value: %w", err)
 		}
 
-		valueLength, _ := parseLength(packet[cursor:])
+		valueLength, _, err := parseLength(packet[cursor:])
+		if err != nil {
+			return err
+		}
 		cursor += valueLength
 		if cursor > len(packet) {
 			return fmt.Errorf("error decoding OID Value: truncated, packet length %d cursor %d", len(packet), cursor)

--- a/v3.go
+++ b/v3.go
@@ -337,7 +337,10 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 		return 0, fmt.Errorf("invalid SNMPV3 Header")
 	}
 
-	_, cursorTmp := parseLength(packet[cursor:])
+	_, cursorTmp, err := parseLength(packet[cursor:])
+	if err != nil {
+		return 0, err
+	}
 	cursor += cursorTmp
 	if cursor > len(packet) {
 		return 0, errors.New("error parsing SNMPV3 message ID: truncted packet")
@@ -402,7 +405,10 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	if PDUType(packet[cursor]) != PDUType(OctetString) {
 		return 0, errors.New("invalid SNMPV3 Security Parameters")
 	}
-	_, cursorTmp = parseLength(packet[cursor:])
+	_, cursorTmp, err = parseLength(packet[cursor:])
+	if err != nil {
+		return 0, err
+	}
 	cursor += cursorTmp
 	if cursor > len(packet) {
 		return 0, errors.New("error parsing SNMPV3 message ID: truncted packet")
@@ -439,7 +445,10 @@ func (x *GoSNMP) decryptPacket(packet []byte, cursor int, response *SnmpPacket) 
 		fallthrough
 	case Sequence:
 		// pdu is plaintext or has been decrypted
-		tlength, cursorTmp := parseLength(packet[cursor:])
+		tlength, cursorTmp, err := parseLength(packet[cursor:])
+		if err != nil {
+			return nil, 0, err
+		}
 		if decrypted {
 			// truncate padding that might have been included with
 			// the encrypted PDU

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -801,7 +801,10 @@ func (sp *UsmSecurityParameters) encryptPacket(scopedPdu []byte) ([]byte, error)
 }
 
 func (sp *UsmSecurityParameters) decryptPacket(packet []byte, cursor int) ([]byte, error) {
-	_, cursorTmp := parseLength(packet[cursor:])
+	_, cursorTmp, err := parseLength(packet[cursor:])
+	if err != nil {
+		return nil, err
+	}
 	cursorTmp += cursor
 	if cursorTmp > len(packet) {
 		return nil, errors.New("error decrypting ScopedPDU: truncated packet")
@@ -907,7 +910,10 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	if PDUType(packet[cursor]) != Sequence {
 		return 0, errors.New("error parsing SNMPV3 User Security Model parameters")
 	}
-	_, cursorTmp := parseLength(packet[cursor:])
+	_, cursorTmp, err := parseLength(packet[cursor:])
+	if err != nil {
+		return 0, err
+	}
 	cursor += cursorTmp
 	if cursorTmp > len(packet) {
 		return 0, errors.New("error parsing SNMPV3 User Security Model parameters: truncated packet")


### PR DESCRIPTION
* helper.go: add error handling to parseLength to prevent returning invalid data.

follow-up of #354

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>