### PR TITLE
Trap: make Listen() address format consistent with Connect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ NOTE:
 
 ## Unreleased
 
+NOTE: This release changes TrapListener's Listen method to behave similar
+as Connect.
+
+* [CHANGE] Trap: make Listen() address format consistent with Connect() #366
 * [FEATURE] Add LocalAddr setting to bind source address of SNMP queries #342
 
 ## v1.32.0

--- a/examples/tcp_trapserver/main.go
+++ b/examples/tcp_trapserver/main.go
@@ -76,8 +76,9 @@ func Start(address string) {
 	tl := gosnmp.NewTrapListener()
 	tl.OnNewTrap = myTrapHandlerTCP
 	tl.Params = gosnmp.Default
+	tl.Params.Target = address
 
-	err := tl.Listen(address)
+	err := tl.Listen()
 	if err != nil {
 		time.Sleep(1 * time.Second)
 		log.Fatalf("Error in TRAP listen: %s\n", err)

--- a/examples/trapserver/main.go
+++ b/examples/trapserver/main.go
@@ -34,8 +34,10 @@ func main() {
 	tl.OnNewTrap = myTrapHandler
 	tl.Params = g.Default
 	tl.Params.Logger = g.NewLogger(log.New(os.Stdout, "", 0))
+	tl.Params.Port = 9162
+	tl.Params.Target = "0.0.0.0"
 
-	err := tl.Listen("0.0.0.0:9162")
+	err := tl.Listen()
 	if err != nil {
 		log.Panicf("error in listen: %s", err)
 	}

--- a/trap.go
+++ b/trap.go
@@ -7,6 +7,7 @@ package gosnmp
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -320,7 +321,7 @@ func (t *TrapListener) listenTCP(addr string) error {
 // function specified in *TrapListener for every trap received.
 //
 // NOTE: the trap code is currently unreliable when working with snmpv3 - pull requests welcome
-func (t *TrapListener) Listen(addr string) error {
+func (t *TrapListener) Listen() error {
 	if t.Params == nil {
 		t.Params = Default
 	}
@@ -335,6 +336,7 @@ func (t *TrapListener) Listen(addr string) error {
 		t.OnNewTrap = t.debugTrapHandler
 	}
 
+	addr := net.JoinHostPort(t.Params.Target, strconv.Itoa(int(t.Params.Port)))
 	splitted := strings.SplitN(addr, "://", 2)
 	t.proto = udp
 	if len(splitted) > 1 {

--- a/trap_test.go
+++ b/trap_test.go
@@ -18,11 +18,7 @@ import (
 
 const (
 	trapTestAddress = "127.0.0.1"
-
-	// TODO this is bad. Listen and Connect expect different address formats
-	// so we need an int version and a string version - they should be the same.
-	trapTestPort       = 9162
-	trapTestPortString = "9162"
+	trapTestPort    = 9162
 
 	trapTestOid     = ".1.2.1234.4.5"
 	trapTestPayload = "TRAPTEST1234"
@@ -166,12 +162,14 @@ func TestSendTrapBasic(t *testing.T) {
 
 	tl.OnNewTrap = makeTestTrapHandler(t, done, Version2c)
 	tl.Params = Default
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
 		// defer close(errch)
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -232,12 +230,14 @@ func TestSendInformBasic(t *testing.T) {
 
 	tl.OnNewTrap = makeTestTrapHandler(t, done, Version2c)
 	tl.Params = Default
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
 		// defer close(errch)
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -312,6 +312,8 @@ func TestSendTrapWithoutWaitingOnListen(t *testing.T) {
 
 	tl.OnNewTrap = makeTestTrapHandler(t, done, Version2c)
 	tl.Params = Default
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	errch := make(chan error)
 	listening := make(chan bool)
@@ -319,7 +321,7 @@ func TestSendTrapWithoutWaitingOnListen(t *testing.T) {
 		// Reduce the chance of necessity for a restart.
 		listening <- true
 
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -391,16 +393,19 @@ func TestSendV1Trap(t *testing.T) {
 
 	tl.OnNewTrap = makeTestTrapHandler(t, done, Version1)
 	tl.Params = Default
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		// defer close(errch)
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
 	}()
-
+	// listener goroutine
 	// Wait until the listener is ready.
 	select {
 	case <-tl.Listening():
@@ -471,11 +476,13 @@ func TestSendV3TrapNoAuthNoPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = NoAuthNoPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -557,11 +564,12 @@ func TestSendV3TrapMD5AuthNoPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthNoPriv
-
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -643,11 +651,12 @@ func TestSendV3TrapSHAAuthNoPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthNoPriv
-
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -730,11 +739,13 @@ func TestSendV3TrapSHAAuthDESPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -818,11 +829,13 @@ func TestSendV3TrapSHAAuthAESPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -906,11 +919,13 @@ func TestSendV3TrapSHAAuthAES192Priv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -993,11 +1008,13 @@ func TestSendV3TrapSHAAuthAES192CPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -1079,11 +1096,13 @@ func TestSendV3TrapSHAAuthAES256Priv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}
@@ -1166,11 +1185,13 @@ func TestSendV3TrapSHAAuthAES256CPriv(t *testing.T) {
 	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
+	tl.Params.Port = trapTestPort
+	tl.Params.Target = trapTestAddress
 
 	// listener goroutine
 	errch := make(chan error)
 	go func() {
-		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		err := tl.Listen()
 		if err != nil {
 			errch <- err
 		}


### PR DESCRIPTION
by defining port and target before making a call to ``Listen()`` like:
```go
       tl.Params.Port = 9162
       tl.Params.Target = "0.0.0.0"
       err := tl.Listen()
```

Breaking change, fixes TODO from ``trap_test.go``

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>