### PR TITLE
Detect negative lengths in parseLength, prevent panic

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -615,6 +615,10 @@ func parseLength(bytes []byte) (int, int, error) {
 		length += 2 + numOctets
 		cursor += 2 + numOctets
 	}
+	if length < 0 {
+		// Invalid data detected, return an error
+		return 0, 0, ErrInvalidPacketLength
+	}
 	return length, cursor, nil
 }
 


### PR DESCRIPTION
This patch avoids a panic by preventing parseLength from returning a negative length value:

```
runtime error: slice bounds out of range :-9088211219834721494] 
```
