### PR TITLE
gosnmp.go/Set(): permit ObjectIdentifier PDU Type

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -417,7 +417,7 @@ func (x *GoSNMP) Set(pdus []SnmpPDU) (result *SnmpPacket, err error) {
 	var packetOut *SnmpPacket
 	switch pdus[0].Type {
 	// TODO test Gauge32
-	case Integer, OctetString, Gauge32, IPAddress:
+	case Integer, OctetString, Gauge32, IPAddress, ObjectIdentifier:
 		packetOut = x.mkSnmpPacket(SetRequest, pdus, 0, 0)
 	default:
 		return nil, fmt.Errorf("ERR:gosnmp currently only supports SNMP SETs for Integers, IPAddress and OctetStrings")


### PR DESCRIPTION
* gosnmp.go/Set(): permit ObjectIdentifier PDU Type

Fixes #375

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>