### PR TITLE
marshal.go: stricter cursor bounds checking in unmarshalPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ number of octets as per ITU-T Rec. X.690 (07/2002).
 * [ENHANCEMENT] helper.go: Interpreting the value of an Opaque type as binary data if the Opaque sub-type cannot be recognized #374
 * [ENHANCEMENT] helper.go: Implemented Opaque type marshaling #374
 * [BUGFIX] marshal.go: Fixed invalid OpaqueFloat and OpaqueDouble marshaling in marshalVarbind() function #374
+* [BUGFIX] marshal.go: stricter cursor bounds checking in unmarshalPayload #384
 
 ## v1.33.0
 

--- a/marshal.go
+++ b/marshal.go
@@ -1034,7 +1034,7 @@ func (x *GoSNMP) unmarshalPayload(packet []byte, cursor int, response *SnmpPacke
 	if len(packet) == 0 {
 		return errors.New("cannot unmarshal nil or empty payload packet")
 	}
-	if cursor > len(packet) {
+	if cursor >= len(packet) {
 		return fmt.Errorf("cannot unmarshal payload, packet length %d cursor %d", len(packet), cursor)
 	}
 	if response == nil {


### PR DESCRIPTION
Stricter bounds checking for cursor in unmarshalPayload
to ensure it does not exceed ``len(packet)``, preventing
panic when receiving a malformed packet.

Special thanks to Amplia Security for disclosing this issue responsibly.

Fixes #381

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>