### PR TITLE
Release v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ NOTE:
 * [ENHANCEMENT]
 * [BUGFIX]
 
-## Unreleased
+## v1.34.0
 
 NOTE: marshalInt32 now always encodes an integer value in the smallest possible
 number of octets as per ITU-T Rec. X.690 (07/2002).


### PR DESCRIPTION
NOTE: marshalInt32 now always encodes an integer value in the smallest possible
number of octets as per ITU-T Rec. X.690 (07/2002).

* [ENHANCEMENT] gosnmp/marshalInt32: adhere to ITU-T Rec. X.690 integer encoding #372
* [ENHANCEMENT] parseInt64: throw error on zero length as per X690 #373
* [ENHANCEMENT] helper.go: Interpreting the value of an Opaque type as binary data if the Opaque sub-type cannot be recognized #374
* [ENHANCEMENT] helper.go: Implemented Opaque type marshaling #374
* [BUGFIX] marshal.go: Fixed invalid OpaqueFloat and OpaqueDouble marshaling in marshalVarbind() function #374
* [BUGFIX] marshal.go: stricter cursor bounds checking in unmarshalPayload #384

Signed-off-by: SuperQ <superq@gmail.com>