### PR TITLE
TrapListener: Support authoritative engineID discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 NOTE: The UnmarshalTrap now returns both an SnmpPacket and an error (#394)
 
-* [ENHANCEMENT] Support authoritative engineID discovery when listening for traps #394
+* [CHANGE] Support authoritative engineID discovery when listening for traps #394
 
 * [CHANGE]
 * [FEATURE]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-NOTE: The signature of UnmarshalTrap now returns an additional error: #394
+NOTE: The UnmarshalTrap now returns both an SnmpPacket and an error (#394)
 
 * [ENHANCEMENT] Support authoritative engineID discovery when listening for traps #394
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## unreleased
 
-NOTE:
+NOTE: The signature of UnmarshalTrap now returns an additional error: #394
+
+* [ENHANCEMENT] Support authoritative engineID discovery when listening for traps #394
 
 * [CHANGE]
 * [FEATURE]

--- a/interface.go
+++ b/interface.go
@@ -76,7 +76,7 @@ type Handler interface {
 	SendTrap(trap SnmpTrap) (result *SnmpPacket, err error)
 
 	// UnmarshalTrap unpacks the SNMP Trap.
-	UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket)
+	UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket, err error)
 
 	// Set sends an SNMP SET request
 	Set(pdus []SnmpPDU) (result *SnmpPacket, err error)

--- a/mocks/gosnmp_mock.go
+++ b/mocks/gosnmp_mock.go
@@ -12,146 +12,30 @@ import (
 	gosnmp "github.com/gosnmp/gosnmp"
 )
 
-// MockHandler is a mock of Handler interface
+// MockHandler is a mock of Handler interface.
 type MockHandler struct {
 	ctrl     *gomock.Controller
 	recorder *MockHandlerMockRecorder
 }
 
-// MockHandlerMockRecorder is the mock recorder for MockHandler
+// MockHandlerMockRecorder is the mock recorder for MockHandler.
 type MockHandlerMockRecorder struct {
 	mock *MockHandler
 }
 
-// NewMockHandler creates a new mock instance
+// NewMockHandler creates a new mock instance.
 func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 	mock := &MockHandler{ctrl: ctrl}
 	mock.recorder = &MockHandlerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
 }
 
-// Connect mocks base method
-func (m *MockHandler) Connect() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Connect")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Connect indicates an expected call of Connect
-func (mr *MockHandlerMockRecorder) Connect() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockHandler)(nil).Connect))
-}
-
-// ConnectIPv4 mocks base method
-func (m *MockHandler) ConnectIPv4() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectIPv4")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ConnectIPv4 indicates an expected call of ConnectIPv4
-func (mr *MockHandlerMockRecorder) ConnectIPv4() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectIPv4", reflect.TypeOf((*MockHandler)(nil).ConnectIPv4))
-}
-
-// ConnectIPv6 mocks base method
-func (m *MockHandler) ConnectIPv6() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConnectIPv6")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ConnectIPv6 indicates an expected call of ConnectIPv6
-func (mr *MockHandlerMockRecorder) ConnectIPv6() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectIPv6", reflect.TypeOf((*MockHandler)(nil).ConnectIPv6))
-}
-
-// Get mocks base method
-func (m *MockHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", oids)
-	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Get indicates an expected call of Get
-func (mr *MockHandlerMockRecorder) Get(oids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockHandler)(nil).Get), oids)
-}
-
-// GetBulk mocks base method
-func (m *MockHandler) GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBulk", oids, nonRepeaters, maxRepetitions)
-	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBulk indicates an expected call of GetBulk
-func (mr *MockHandlerMockRecorder) GetBulk(oids, nonRepeaters, maxRepetitions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBulk", reflect.TypeOf((*MockHandler)(nil).GetBulk), oids, nonRepeaters, maxRepetitions)
-}
-
-// GetNext mocks base method
-func (m *MockHandler) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNext", oids)
-	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNext indicates an expected call of GetNext
-func (mr *MockHandlerMockRecorder) GetNext(oids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNext", reflect.TypeOf((*MockHandler)(nil).GetNext), oids)
-}
-
-// Walk mocks base method
-func (m *MockHandler) Walk(rootOid string, walkFn gosnmp.WalkFunc) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Walk", rootOid, walkFn)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Walk indicates an expected call of Walk
-func (mr *MockHandlerMockRecorder) Walk(rootOid, walkFn interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockHandler)(nil).Walk), rootOid, walkFn)
-}
-
-// WalkAll mocks base method
-func (m *MockHandler) WalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WalkAll", rootOid)
-	ret0, _ := ret[0].([]gosnmp.SnmpPDU)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WalkAll indicates an expected call of WalkAll
-func (mr *MockHandlerMockRecorder) WalkAll(rootOid interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkAll", reflect.TypeOf((*MockHandler)(nil).WalkAll), rootOid)
-}
-
-// BulkWalk mocks base method
+// BulkWalk mocks base method.
 func (m *MockHandler) BulkWalk(rootOid string, walkFn gosnmp.WalkFunc) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkWalk", rootOid, walkFn)
@@ -159,13 +43,13 @@ func (m *MockHandler) BulkWalk(rootOid string, walkFn gosnmp.WalkFunc) error {
 	return ret0
 }
 
-// BulkWalk indicates an expected call of BulkWalk
+// BulkWalk indicates an expected call of BulkWalk.
 func (mr *MockHandlerMockRecorder) BulkWalk(rootOid, walkFn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkWalk", reflect.TypeOf((*MockHandler)(nil).BulkWalk), rootOid, walkFn)
 }
 
-// BulkWalkAll mocks base method
+// BulkWalkAll mocks base method.
 func (m *MockHandler) BulkWalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BulkWalkAll", rootOid)
@@ -174,13 +58,308 @@ func (m *MockHandler) BulkWalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
 	return ret0, ret1
 }
 
-// BulkWalkAll indicates an expected call of BulkWalkAll
+// BulkWalkAll indicates an expected call of BulkWalkAll.
 func (mr *MockHandlerMockRecorder) BulkWalkAll(rootOid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkWalkAll", reflect.TypeOf((*MockHandler)(nil).BulkWalkAll), rootOid)
 }
 
-// SendTrap mocks base method
+// Check mocks base method.
+func (m *MockHandler) Check(err error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Check", err)
+}
+
+// Check indicates an expected call of Check.
+func (mr *MockHandlerMockRecorder) Check(err interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockHandler)(nil).Check), err)
+}
+
+// Close mocks base method.
+func (m *MockHandler) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockHandlerMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHandler)(nil).Close))
+}
+
+// Community mocks base method.
+func (m *MockHandler) Community() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Community")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Community indicates an expected call of Community.
+func (mr *MockHandlerMockRecorder) Community() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Community", reflect.TypeOf((*MockHandler)(nil).Community))
+}
+
+// Connect mocks base method.
+func (m *MockHandler) Connect() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Connect")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Connect indicates an expected call of Connect.
+func (mr *MockHandlerMockRecorder) Connect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockHandler)(nil).Connect))
+}
+
+// ConnectIPv4 mocks base method.
+func (m *MockHandler) ConnectIPv4() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectIPv4")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConnectIPv4 indicates an expected call of ConnectIPv4.
+func (mr *MockHandlerMockRecorder) ConnectIPv4() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectIPv4", reflect.TypeOf((*MockHandler)(nil).ConnectIPv4))
+}
+
+// ConnectIPv6 mocks base method.
+func (m *MockHandler) ConnectIPv6() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConnectIPv6")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConnectIPv6 indicates an expected call of ConnectIPv6.
+func (mr *MockHandlerMockRecorder) ConnectIPv6() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectIPv6", reflect.TypeOf((*MockHandler)(nil).ConnectIPv6))
+}
+
+// ContextEngineID mocks base method.
+func (m *MockHandler) ContextEngineID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContextEngineID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ContextEngineID indicates an expected call of ContextEngineID.
+func (mr *MockHandlerMockRecorder) ContextEngineID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContextEngineID", reflect.TypeOf((*MockHandler)(nil).ContextEngineID))
+}
+
+// ContextName mocks base method.
+func (m *MockHandler) ContextName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContextName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ContextName indicates an expected call of ContextName.
+func (mr *MockHandlerMockRecorder) ContextName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContextName", reflect.TypeOf((*MockHandler)(nil).ContextName))
+}
+
+// Get mocks base method.
+func (m *MockHandler) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", oids)
+	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockHandlerMockRecorder) Get(oids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockHandler)(nil).Get), oids)
+}
+
+// GetBulk mocks base method.
+func (m *MockHandler) GetBulk(oids []string, nonRepeaters uint8, maxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBulk", oids, nonRepeaters, maxRepetitions)
+	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBulk indicates an expected call of GetBulk.
+func (mr *MockHandlerMockRecorder) GetBulk(oids, nonRepeaters, maxRepetitions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBulk", reflect.TypeOf((*MockHandler)(nil).GetBulk), oids, nonRepeaters, maxRepetitions)
+}
+
+// GetExponentialTimeout mocks base method.
+func (m *MockHandler) GetExponentialTimeout() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExponentialTimeout")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetExponentialTimeout indicates an expected call of GetExponentialTimeout.
+func (mr *MockHandlerMockRecorder) GetExponentialTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExponentialTimeout", reflect.TypeOf((*MockHandler)(nil).GetExponentialTimeout))
+}
+
+// GetNext mocks base method.
+func (m *MockHandler) GetNext(oids []string) (*gosnmp.SnmpPacket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNext", oids)
+	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNext indicates an expected call of GetNext.
+func (mr *MockHandlerMockRecorder) GetNext(oids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNext", reflect.TypeOf((*MockHandler)(nil).GetNext), oids)
+}
+
+// Logger mocks base method.
+func (m *MockHandler) Logger() gosnmp.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Logger")
+	ret0, _ := ret[0].(gosnmp.Logger)
+	return ret0
+}
+
+// Logger indicates an expected call of Logger.
+func (mr *MockHandlerMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockHandler)(nil).Logger))
+}
+
+// MaxOids mocks base method.
+func (m *MockHandler) MaxOids() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxOids")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// MaxOids indicates an expected call of MaxOids.
+func (mr *MockHandlerMockRecorder) MaxOids() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxOids", reflect.TypeOf((*MockHandler)(nil).MaxOids))
+}
+
+// MaxRepetitions mocks base method.
+func (m *MockHandler) MaxRepetitions() uint32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MaxRepetitions")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// MaxRepetitions indicates an expected call of MaxRepetitions.
+func (mr *MockHandlerMockRecorder) MaxRepetitions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxRepetitions", reflect.TypeOf((*MockHandler)(nil).MaxRepetitions))
+}
+
+// MsgFlags mocks base method.
+func (m *MockHandler) MsgFlags() gosnmp.SnmpV3MsgFlags {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MsgFlags")
+	ret0, _ := ret[0].(gosnmp.SnmpV3MsgFlags)
+	return ret0
+}
+
+// MsgFlags indicates an expected call of MsgFlags.
+func (mr *MockHandlerMockRecorder) MsgFlags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsgFlags", reflect.TypeOf((*MockHandler)(nil).MsgFlags))
+}
+
+// NonRepeaters mocks base method.
+func (m *MockHandler) NonRepeaters() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NonRepeaters")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// NonRepeaters indicates an expected call of NonRepeaters.
+func (mr *MockHandlerMockRecorder) NonRepeaters() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonRepeaters", reflect.TypeOf((*MockHandler)(nil).NonRepeaters))
+}
+
+// Port mocks base method.
+func (m *MockHandler) Port() uint16 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Port")
+	ret0, _ := ret[0].(uint16)
+	return ret0
+}
+
+// Port indicates an expected call of Port.
+func (mr *MockHandlerMockRecorder) Port() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Port", reflect.TypeOf((*MockHandler)(nil).Port))
+}
+
+// Retries mocks base method.
+func (m *MockHandler) Retries() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Retries")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Retries indicates an expected call of Retries.
+func (mr *MockHandlerMockRecorder) Retries() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retries", reflect.TypeOf((*MockHandler)(nil).Retries))
+}
+
+// SecurityModel mocks base method.
+func (m *MockHandler) SecurityModel() gosnmp.SnmpV3SecurityModel {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecurityModel")
+	ret0, _ := ret[0].(gosnmp.SnmpV3SecurityModel)
+	return ret0
+}
+
+// SecurityModel indicates an expected call of SecurityModel.
+func (mr *MockHandlerMockRecorder) SecurityModel() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecurityModel", reflect.TypeOf((*MockHandler)(nil).SecurityModel))
+}
+
+// SecurityParameters mocks base method.
+func (m *MockHandler) SecurityParameters() gosnmp.SnmpV3SecurityParameters {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecurityParameters")
+	ret0, _ := ret[0].(gosnmp.SnmpV3SecurityParameters)
+	return ret0
+}
+
+// SecurityParameters indicates an expected call of SecurityParameters.
+func (mr *MockHandlerMockRecorder) SecurityParameters() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecurityParameters", reflect.TypeOf((*MockHandler)(nil).SecurityParameters))
+}
+
+// SendTrap mocks base method.
 func (m *MockHandler) SendTrap(trap gosnmp.SnmpTrap) (*gosnmp.SnmpPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendTrap", trap)
@@ -189,27 +368,13 @@ func (m *MockHandler) SendTrap(trap gosnmp.SnmpTrap) (*gosnmp.SnmpPacket, error)
 	return ret0, ret1
 }
 
-// SendTrap indicates an expected call of SendTrap
+// SendTrap indicates an expected call of SendTrap.
 func (mr *MockHandlerMockRecorder) SendTrap(trap interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendTrap", reflect.TypeOf((*MockHandler)(nil).SendTrap), trap)
 }
 
-// UnmarshalTrap mocks base method
-func (m *MockHandler) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) *gosnmp.SnmpPacket {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnmarshalTrap", trap, useResponseSecurityParameters)
-	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
-	return ret0
-}
-
-// UnmarshalTrap indicates an expected call of UnmarshalTrap
-func (mr *MockHandlerMockRecorder) UnmarshalTrap(trap, useResponseSecurityParameters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalTrap", reflect.TypeOf((*MockHandler)(nil).UnmarshalTrap), trap, useResponseSecurityParameters)
-}
-
-// Set mocks base method
+// Set mocks base method.
 func (m *MockHandler) Set(pdus []gosnmp.SnmpPDU) (*gosnmp.SnmpPacket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Set", pdus)
@@ -218,39 +383,205 @@ func (m *MockHandler) Set(pdus []gosnmp.SnmpPDU) (*gosnmp.SnmpPacket, error) {
 	return ret0, ret1
 }
 
-// Set indicates an expected call of Set
+// Set indicates an expected call of Set.
 func (mr *MockHandlerMockRecorder) Set(pdus interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockHandler)(nil).Set), pdus)
 }
 
-// Check mocks base method
-func (m *MockHandler) Check(err error) {
+// SetCommunity mocks base method.
+func (m *MockHandler) SetCommunity(community string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Check", err)
+	m.ctrl.Call(m, "SetCommunity", community)
 }
 
-// Check indicates an expected call of Check
-func (mr *MockHandlerMockRecorder) Check(err interface{}) *gomock.Call {
+// SetCommunity indicates an expected call of SetCommunity.
+func (mr *MockHandlerMockRecorder) SetCommunity(community interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockHandler)(nil).Check), err)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCommunity", reflect.TypeOf((*MockHandler)(nil).SetCommunity), community)
 }
 
-// Close mocks base method
-func (m *MockHandler) Close() error {
+// SetContextEngineID mocks base method.
+func (m *MockHandler) SetContextEngineID(contextEngineID string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "SetContextEngineID", contextEngineID)
 }
 
-// Close indicates an expected call of Close
-func (mr *MockHandlerMockRecorder) Close() *gomock.Call {
+// SetContextEngineID indicates an expected call of SetContextEngineID.
+func (mr *MockHandlerMockRecorder) SetContextEngineID(contextEngineID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHandler)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextEngineID", reflect.TypeOf((*MockHandler)(nil).SetContextEngineID), contextEngineID)
 }
 
-// Target mocks base method
+// SetContextName mocks base method.
+func (m *MockHandler) SetContextName(contextName string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetContextName", contextName)
+}
+
+// SetContextName indicates an expected call of SetContextName.
+func (mr *MockHandlerMockRecorder) SetContextName(contextName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextName", reflect.TypeOf((*MockHandler)(nil).SetContextName), contextName)
+}
+
+// SetExponentialTimeout mocks base method.
+func (m *MockHandler) SetExponentialTimeout(value bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetExponentialTimeout", value)
+}
+
+// SetExponentialTimeout indicates an expected call of SetExponentialTimeout.
+func (mr *MockHandlerMockRecorder) SetExponentialTimeout(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExponentialTimeout", reflect.TypeOf((*MockHandler)(nil).SetExponentialTimeout), value)
+}
+
+// SetLogger mocks base method.
+func (m *MockHandler) SetLogger(logger gosnmp.Logger) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLogger", logger)
+}
+
+// SetLogger indicates an expected call of SetLogger.
+func (mr *MockHandlerMockRecorder) SetLogger(logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockHandler)(nil).SetLogger), logger)
+}
+
+// SetMaxOids mocks base method.
+func (m *MockHandler) SetMaxOids(maxOids int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxOids", maxOids)
+}
+
+// SetMaxOids indicates an expected call of SetMaxOids.
+func (mr *MockHandlerMockRecorder) SetMaxOids(maxOids interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxOids", reflect.TypeOf((*MockHandler)(nil).SetMaxOids), maxOids)
+}
+
+// SetMaxRepetitions mocks base method.
+func (m *MockHandler) SetMaxRepetitions(maxRepetitions uint32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMaxRepetitions", maxRepetitions)
+}
+
+// SetMaxRepetitions indicates an expected call of SetMaxRepetitions.
+func (mr *MockHandlerMockRecorder) SetMaxRepetitions(maxRepetitions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxRepetitions", reflect.TypeOf((*MockHandler)(nil).SetMaxRepetitions), maxRepetitions)
+}
+
+// SetMsgFlags mocks base method.
+func (m *MockHandler) SetMsgFlags(msgFlags gosnmp.SnmpV3MsgFlags) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetMsgFlags", msgFlags)
+}
+
+// SetMsgFlags indicates an expected call of SetMsgFlags.
+func (mr *MockHandlerMockRecorder) SetMsgFlags(msgFlags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMsgFlags", reflect.TypeOf((*MockHandler)(nil).SetMsgFlags), msgFlags)
+}
+
+// SetNonRepeaters mocks base method.
+func (m *MockHandler) SetNonRepeaters(nonRepeaters int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetNonRepeaters", nonRepeaters)
+}
+
+// SetNonRepeaters indicates an expected call of SetNonRepeaters.
+func (mr *MockHandlerMockRecorder) SetNonRepeaters(nonRepeaters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonRepeaters", reflect.TypeOf((*MockHandler)(nil).SetNonRepeaters), nonRepeaters)
+}
+
+// SetPort mocks base method.
+func (m *MockHandler) SetPort(port uint16) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetPort", port)
+}
+
+// SetPort indicates an expected call of SetPort.
+func (mr *MockHandlerMockRecorder) SetPort(port interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPort", reflect.TypeOf((*MockHandler)(nil).SetPort), port)
+}
+
+// SetRetries mocks base method.
+func (m *MockHandler) SetRetries(retries int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetRetries", retries)
+}
+
+// SetRetries indicates an expected call of SetRetries.
+func (mr *MockHandlerMockRecorder) SetRetries(retries interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRetries", reflect.TypeOf((*MockHandler)(nil).SetRetries), retries)
+}
+
+// SetSecurityModel mocks base method.
+func (m *MockHandler) SetSecurityModel(securityModel gosnmp.SnmpV3SecurityModel) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSecurityModel", securityModel)
+}
+
+// SetSecurityModel indicates an expected call of SetSecurityModel.
+func (mr *MockHandlerMockRecorder) SetSecurityModel(securityModel interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecurityModel", reflect.TypeOf((*MockHandler)(nil).SetSecurityModel), securityModel)
+}
+
+// SetSecurityParameters mocks base method.
+func (m *MockHandler) SetSecurityParameters(securityParameters gosnmp.SnmpV3SecurityParameters) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSecurityParameters", securityParameters)
+}
+
+// SetSecurityParameters indicates an expected call of SetSecurityParameters.
+func (mr *MockHandlerMockRecorder) SetSecurityParameters(securityParameters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecurityParameters", reflect.TypeOf((*MockHandler)(nil).SetSecurityParameters), securityParameters)
+}
+
+// SetTarget mocks base method.
+func (m *MockHandler) SetTarget(target string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTarget", target)
+}
+
+// SetTarget indicates an expected call of SetTarget.
+func (mr *MockHandlerMockRecorder) SetTarget(target interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTarget", reflect.TypeOf((*MockHandler)(nil).SetTarget), target)
+}
+
+// SetTimeout mocks base method.
+func (m *MockHandler) SetTimeout(timeout time.Duration) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTimeout", timeout)
+}
+
+// SetTimeout indicates an expected call of SetTimeout.
+func (mr *MockHandlerMockRecorder) SetTimeout(timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimeout", reflect.TypeOf((*MockHandler)(nil).SetTimeout), timeout)
+}
+
+// SetVersion mocks base method.
+func (m *MockHandler) SetVersion(version gosnmp.SnmpVersion) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVersion", version)
+}
+
+// SetVersion indicates an expected call of SetVersion.
+func (mr *MockHandlerMockRecorder) SetVersion(version interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersion", reflect.TypeOf((*MockHandler)(nil).SetVersion), version)
+}
+
+// Target mocks base method.
 func (m *MockHandler) Target() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Target")
@@ -258,103 +589,13 @@ func (m *MockHandler) Target() string {
 	return ret0
 }
 
-// Target indicates an expected call of Target
+// Target indicates an expected call of Target.
 func (mr *MockHandlerMockRecorder) Target() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Target", reflect.TypeOf((*MockHandler)(nil).Target))
 }
 
-// SetTarget mocks base method
-func (m *MockHandler) SetTarget(target string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTarget", target)
-}
-
-// SetTarget indicates an expected call of SetTarget
-func (mr *MockHandlerMockRecorder) SetTarget(target interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTarget", reflect.TypeOf((*MockHandler)(nil).SetTarget), target)
-}
-
-// Port mocks base method
-func (m *MockHandler) Port() uint16 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Port")
-	ret0, _ := ret[0].(uint16)
-	return ret0
-}
-
-// Port indicates an expected call of Port
-func (mr *MockHandlerMockRecorder) Port() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Port", reflect.TypeOf((*MockHandler)(nil).Port))
-}
-
-// SetPort mocks base method
-func (m *MockHandler) SetPort(port uint16) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetPort", port)
-}
-
-// SetPort indicates an expected call of SetPort
-func (mr *MockHandlerMockRecorder) SetPort(port interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPort", reflect.TypeOf((*MockHandler)(nil).SetPort), port)
-}
-
-// Community mocks base method
-func (m *MockHandler) Community() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Community")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Community indicates an expected call of Community
-func (mr *MockHandlerMockRecorder) Community() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Community", reflect.TypeOf((*MockHandler)(nil).Community))
-}
-
-// SetCommunity mocks base method
-func (m *MockHandler) SetCommunity(community string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetCommunity", community)
-}
-
-// SetCommunity indicates an expected call of SetCommunity
-func (mr *MockHandlerMockRecorder) SetCommunity(community interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCommunity", reflect.TypeOf((*MockHandler)(nil).SetCommunity), community)
-}
-
-// Version mocks base method
-func (m *MockHandler) Version() gosnmp.SnmpVersion {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Version")
-	ret0, _ := ret[0].(gosnmp.SnmpVersion)
-	return ret0
-}
-
-// Version indicates an expected call of Version
-func (mr *MockHandlerMockRecorder) Version() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockHandler)(nil).Version))
-}
-
-// SetVersion mocks base method
-func (m *MockHandler) SetVersion(version gosnmp.SnmpVersion) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetVersion", version)
-}
-
-// SetVersion indicates an expected call of SetVersion
-func (mr *MockHandlerMockRecorder) SetVersion(version interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersion", reflect.TypeOf((*MockHandler)(nil).SetVersion), version)
-}
-
-// Timeout mocks base method
+// Timeout mocks base method.
 func (m *MockHandler) Timeout() time.Duration {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Timeout")
@@ -362,306 +603,66 @@ func (m *MockHandler) Timeout() time.Duration {
 	return ret0
 }
 
-// Timeout indicates an expected call of Timeout
+// Timeout indicates an expected call of Timeout.
 func (mr *MockHandlerMockRecorder) Timeout() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timeout", reflect.TypeOf((*MockHandler)(nil).Timeout))
 }
 
-// SetTimeout mocks base method
-func (m *MockHandler) SetTimeout(timeout time.Duration) {
+// UnmarshalTrap mocks base method.
+func (m *MockHandler) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (*gosnmp.SnmpPacket, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetTimeout", timeout)
+	ret := m.ctrl.Call(m, "UnmarshalTrap", trap, useResponseSecurityParameters)
+	ret0, _ := ret[0].(*gosnmp.SnmpPacket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// SetTimeout indicates an expected call of SetTimeout
-func (mr *MockHandlerMockRecorder) SetTimeout(timeout interface{}) *gomock.Call {
+// UnmarshalTrap indicates an expected call of UnmarshalTrap.
+func (mr *MockHandlerMockRecorder) UnmarshalTrap(trap, useResponseSecurityParameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTimeout", reflect.TypeOf((*MockHandler)(nil).SetTimeout), timeout)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmarshalTrap", reflect.TypeOf((*MockHandler)(nil).UnmarshalTrap), trap, useResponseSecurityParameters)
 }
 
-// Retries mocks base method
-func (m *MockHandler) Retries() int {
+// Version mocks base method.
+func (m *MockHandler) Version() gosnmp.SnmpVersion {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Retries")
-	ret0, _ := ret[0].(int)
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(gosnmp.SnmpVersion)
 	return ret0
 }
 
-// Retries indicates an expected call of Retries
-func (mr *MockHandlerMockRecorder) Retries() *gomock.Call {
+// Version indicates an expected call of Version.
+func (mr *MockHandlerMockRecorder) Version() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Retries", reflect.TypeOf((*MockHandler)(nil).Retries))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockHandler)(nil).Version))
 }
 
-// SetRetries mocks base method
-func (m *MockHandler) SetRetries(retries int) {
+// Walk mocks base method.
+func (m *MockHandler) Walk(rootOid string, walkFn gosnmp.WalkFunc) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetRetries", retries)
-}
-
-// SetRetries indicates an expected call of SetRetries
-func (mr *MockHandlerMockRecorder) SetRetries(retries interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRetries", reflect.TypeOf((*MockHandler)(nil).SetRetries), retries)
-}
-
-// GetExponentialTimeout mocks base method
-func (m *MockHandler) GetExponentialTimeout() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExponentialTimeout")
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "Walk", rootOid, walkFn)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GetExponentialTimeout indicates an expected call of GetExponentialTimeout
-func (mr *MockHandlerMockRecorder) GetExponentialTimeout() *gomock.Call {
+// Walk indicates an expected call of Walk.
+func (mr *MockHandlerMockRecorder) Walk(rootOid, walkFn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExponentialTimeout", reflect.TypeOf((*MockHandler)(nil).GetExponentialTimeout))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Walk", reflect.TypeOf((*MockHandler)(nil).Walk), rootOid, walkFn)
 }
 
-// SetExponentialTimeout mocks base method
-func (m *MockHandler) SetExponentialTimeout(value bool) {
+// WalkAll mocks base method.
+func (m *MockHandler) WalkAll(rootOid string) ([]gosnmp.SnmpPDU, error) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetExponentialTimeout", value)
+	ret := m.ctrl.Call(m, "WalkAll", rootOid)
+	ret0, _ := ret[0].([]gosnmp.SnmpPDU)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// SetExponentialTimeout indicates an expected call of SetExponentialTimeout
-func (mr *MockHandlerMockRecorder) SetExponentialTimeout(value interface{}) *gomock.Call {
+// WalkAll indicates an expected call of WalkAll.
+func (mr *MockHandlerMockRecorder) WalkAll(rootOid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExponentialTimeout", reflect.TypeOf((*MockHandler)(nil).SetExponentialTimeout), value)
-}
-
-// Logger mocks base method
-func (m *MockHandler) Logger() gosnmp.Logger {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Logger")
-	ret0, _ := ret[0].(gosnmp.Logger)
-	return ret0
-}
-
-// Logger indicates an expected call of Logger
-func (mr *MockHandlerMockRecorder) Logger() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockHandler)(nil).Logger))
-}
-
-// SetLogger mocks base method
-func (m *MockHandler) SetLogger(logger gosnmp.Logger) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLogger", logger)
-}
-
-// SetLogger indicates an expected call of SetLogger
-func (mr *MockHandlerMockRecorder) SetLogger(logger interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLogger", reflect.TypeOf((*MockHandler)(nil).SetLogger), logger)
-}
-
-// MaxOids mocks base method
-func (m *MockHandler) MaxOids() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaxOids")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// MaxOids indicates an expected call of MaxOids
-func (mr *MockHandlerMockRecorder) MaxOids() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxOids", reflect.TypeOf((*MockHandler)(nil).MaxOids))
-}
-
-// SetMaxOids mocks base method
-func (m *MockHandler) SetMaxOids(maxOids int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMaxOids", maxOids)
-}
-
-// SetMaxOids indicates an expected call of SetMaxOids
-func (mr *MockHandlerMockRecorder) SetMaxOids(maxOids interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxOids", reflect.TypeOf((*MockHandler)(nil).SetMaxOids), maxOids)
-}
-
-// MaxRepetitions mocks base method
-func (m *MockHandler) MaxRepetitions() uint32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MaxRepetitions")
-	ret0, _ := ret[0].(uint32)
-	return ret0
-}
-
-// MaxRepetitions indicates an expected call of MaxRepetitions
-func (mr *MockHandlerMockRecorder) MaxRepetitions() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxRepetitions", reflect.TypeOf((*MockHandler)(nil).MaxRepetitions))
-}
-
-// SetMaxRepetitions mocks base method
-func (m *MockHandler) SetMaxRepetitions(maxRepetitions uint32) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMaxRepetitions", maxRepetitions)
-}
-
-// SetMaxRepetitions indicates an expected call of SetMaxRepetitions
-func (mr *MockHandlerMockRecorder) SetMaxRepetitions(maxRepetitions interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMaxRepetitions", reflect.TypeOf((*MockHandler)(nil).SetMaxRepetitions), maxRepetitions)
-}
-
-// NonRepeaters mocks base method
-func (m *MockHandler) NonRepeaters() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NonRepeaters")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// NonRepeaters indicates an expected call of NonRepeaters
-func (mr *MockHandlerMockRecorder) NonRepeaters() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonRepeaters", reflect.TypeOf((*MockHandler)(nil).NonRepeaters))
-}
-
-// SetNonRepeaters mocks base method
-func (m *MockHandler) SetNonRepeaters(nonRepeaters int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetNonRepeaters", nonRepeaters)
-}
-
-// SetNonRepeaters indicates an expected call of SetNonRepeaters
-func (mr *MockHandlerMockRecorder) SetNonRepeaters(nonRepeaters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonRepeaters", reflect.TypeOf((*MockHandler)(nil).SetNonRepeaters), nonRepeaters)
-}
-
-// MsgFlags mocks base method
-func (m *MockHandler) MsgFlags() gosnmp.SnmpV3MsgFlags {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MsgFlags")
-	ret0, _ := ret[0].(gosnmp.SnmpV3MsgFlags)
-	return ret0
-}
-
-// MsgFlags indicates an expected call of MsgFlags
-func (mr *MockHandlerMockRecorder) MsgFlags() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsgFlags", reflect.TypeOf((*MockHandler)(nil).MsgFlags))
-}
-
-// SetMsgFlags mocks base method
-func (m *MockHandler) SetMsgFlags(msgFlags gosnmp.SnmpV3MsgFlags) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetMsgFlags", msgFlags)
-}
-
-// SetMsgFlags indicates an expected call of SetMsgFlags
-func (mr *MockHandlerMockRecorder) SetMsgFlags(msgFlags interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMsgFlags", reflect.TypeOf((*MockHandler)(nil).SetMsgFlags), msgFlags)
-}
-
-// SecurityModel mocks base method
-func (m *MockHandler) SecurityModel() gosnmp.SnmpV3SecurityModel {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecurityModel")
-	ret0, _ := ret[0].(gosnmp.SnmpV3SecurityModel)
-	return ret0
-}
-
-// SecurityModel indicates an expected call of SecurityModel
-func (mr *MockHandlerMockRecorder) SecurityModel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecurityModel", reflect.TypeOf((*MockHandler)(nil).SecurityModel))
-}
-
-// SetSecurityModel mocks base method
-func (m *MockHandler) SetSecurityModel(securityModel gosnmp.SnmpV3SecurityModel) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSecurityModel", securityModel)
-}
-
-// SetSecurityModel indicates an expected call of SetSecurityModel
-func (mr *MockHandlerMockRecorder) SetSecurityModel(securityModel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecurityModel", reflect.TypeOf((*MockHandler)(nil).SetSecurityModel), securityModel)
-}
-
-// SecurityParameters mocks base method
-func (m *MockHandler) SecurityParameters() gosnmp.SnmpV3SecurityParameters {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecurityParameters")
-	ret0, _ := ret[0].(gosnmp.SnmpV3SecurityParameters)
-	return ret0
-}
-
-// SecurityParameters indicates an expected call of SecurityParameters
-func (mr *MockHandlerMockRecorder) SecurityParameters() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecurityParameters", reflect.TypeOf((*MockHandler)(nil).SecurityParameters))
-}
-
-// SetSecurityParameters mocks base method
-func (m *MockHandler) SetSecurityParameters(securityParameters gosnmp.SnmpV3SecurityParameters) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSecurityParameters", securityParameters)
-}
-
-// SetSecurityParameters indicates an expected call of SetSecurityParameters
-func (mr *MockHandlerMockRecorder) SetSecurityParameters(securityParameters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecurityParameters", reflect.TypeOf((*MockHandler)(nil).SetSecurityParameters), securityParameters)
-}
-
-// ContextEngineID mocks base method
-func (m *MockHandler) ContextEngineID() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContextEngineID")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ContextEngineID indicates an expected call of ContextEngineID
-func (mr *MockHandlerMockRecorder) ContextEngineID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContextEngineID", reflect.TypeOf((*MockHandler)(nil).ContextEngineID))
-}
-
-// SetContextEngineID mocks base method
-func (m *MockHandler) SetContextEngineID(contextEngineID string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetContextEngineID", contextEngineID)
-}
-
-// SetContextEngineID indicates an expected call of SetContextEngineID
-func (mr *MockHandlerMockRecorder) SetContextEngineID(contextEngineID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextEngineID", reflect.TypeOf((*MockHandler)(nil).SetContextEngineID), contextEngineID)
-}
-
-// ContextName mocks base method
-func (m *MockHandler) ContextName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContextName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// ContextName indicates an expected call of ContextName
-func (mr *MockHandlerMockRecorder) ContextName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContextName", reflect.TypeOf((*MockHandler)(nil).ContextName))
-}
-
-// SetContextName mocks base method
-func (m *MockHandler) SetContextName(contextName string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetContextName", contextName)
-}
-
-// SetContextName indicates an expected call of SetContextName
-func (mr *MockHandlerMockRecorder) SetContextName(contextName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContextName", reflect.TypeOf((*MockHandler)(nil).SetContextName), contextName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WalkAll", reflect.TypeOf((*MockHandler)(nil).WalkAll), rootOid)
 }

--- a/trap.go
+++ b/trap.go
@@ -5,6 +5,7 @@
 package gosnmp
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -171,6 +172,26 @@ func (t *TrapListener) Close() {
 	}
 }
 
+// SendUDP sends a given SnmpPacket to the provided address using the currently opened connection.
+func (t *TrapListener) SendUDP(packet *SnmpPacket, addr *net.UDPAddr) error {
+	ob, err := packet.marshalMsg()
+	if err != nil {
+		return fmt.Errorf("error marshaling SnmpPacket: %w", err)
+	}
+
+	// Send the return packet back.
+	count, err := t.conn.WriteTo(ob, addr)
+	if err != nil {
+		return fmt.Errorf("error sending SnmpPacket: %w", err)
+	}
+
+	// This isn't fatal, but should be logged.
+	if count != len(ob) {
+		t.Params.Logger.Printf("Failed to send all bytes of SnmpPacket!\n")
+	}
+	return nil
+}
+
 func (t *TrapListener) listenUDP(addr string) error {
 	// udp
 
@@ -207,55 +228,88 @@ func (t *TrapListener) listenUDP(addr string) error {
 			}
 
 			msg := buf[:rlen]
-			traps := t.Params.UnmarshalTrap(msg, false)
-
-			if traps != nil {
-				// Here we assume that t.OnNewTrap will not alter the contents
-				// of the PDU (per documentation, because Go does not have
-				// compile-time const checking).  We don't pass a copy because
-				// the SnmpPacket type is somewhat large, but we could without
-				// violating any implicit or explicit spec.
-				t.OnNewTrap(traps, remote)
-
-				// If it was an Inform request, we need to send a response.
-				if traps.PDUType == InformRequest { //nolint:whitespace
-
-					// Reuse the packet, since we're supposed to send it back
-					// with the exact same variables unless there's an error.
-					// Change the PDUType to the response, though.
-					traps.PDUType = GetResponse
-
-					// If the response can be sent, the error-status is
-					// supposed to be set to noError and the error-index set to
-					// zero.
-					traps.Error = NoError
-					traps.ErrorIndex = 0
-
-					// TODO: Check that the message marshalled is not too large
-					// for the originator to accept and if so, send a tooBig
-					// error PDU per RFC3416 section 4.2.7.  This maximum size,
-					// however, does not have a well-defined mechanism in the
-					// RFC other than using the path MTU (which is difficult to
-					// determine), so it's left to future implementations.
-					ob, err := traps.marshalMsg()
-					if err != nil {
-						return fmt.Errorf("error marshaling INFORM response: %w", err)
+			trap, err := t.Params.UnmarshalTrap(msg, false)
+			if err != nil {
+				t.Params.Logger.Printf("TrapListener: error in UnmarshalTrap %s\n", err)
+				continue
+			}
+			if trap.Version == Version3 && trap.SecurityModel == UserSecurityModel && t.Params.SecurityModel == UserSecurityModel {
+				securityParams, ok := t.Params.SecurityParameters.(*UsmSecurityParameters)
+				if !ok {
+					t.Params.Logger.Printf("TrapListener: Invalid SecurityParameters types")
+				}
+				packetSecurityParams, ok := trap.SecurityParameters.(*UsmSecurityParameters)
+				if !ok {
+					t.Params.Logger.Printf("TrapListener: Invalid SecurityParameters types")
+				}
+				snmpEngineID := securityParams.AuthoritativeEngineID
+				msgAuthoritativeEngineID := packetSecurityParams.AuthoritativeEngineID
+				if msgAuthoritativeEngineID != snmpEngineID {
+					if 4 < len(msgAuthoritativeEngineID) && len(msgAuthoritativeEngineID) < 32 {
+						// RFC3414 3.2.3a: continue processing
+					} else {
+						err := t.reportAuthoritativeEngineID(trap, snmpEngineID, remote)
+						if err != nil {
+							t.Params.Logger.Printf("TrapListener: %s\n", err)
+						}
+						continue
 					}
+				}
+			}
+			// Here we assume that t.OnNewTrap will not alter the contents
+			// of the PDU (per documentation, because Go does not have
+			// compile-time const checking).  We don't pass a copy because
+			// the SnmpPacket type is somewhat large, but we could without
+			// violating any implicit or explicit spec.
+			t.OnNewTrap(trap, remote)
 
-					// Send the return packet back.
-					count, err := t.conn.WriteTo(ob, remote)
-					if err != nil {
-						return fmt.Errorf("error sending INFORM response: %w", err)
-					}
+			// If it was an Inform request, we need to send a response.
+			if trap.PDUType == InformRequest { //nolint:whitespace
 
-					// This isn't fatal, but should be logged.
-					if count != len(ob) {
-						t.Params.Logger.Printf("Failed to send all bytes of INFORM response!\n")
-					}
+				// Reuse the packet, since we're supposed to send it back
+				// with the exact same variables unless there's an error.
+				// Change the PDUType to the response, though.
+				trap.PDUType = GetResponse
+
+				// If the response can be sent, the error-status is
+				// supposed to be set to noError and the error-index set to
+				// zero.
+				trap.Error = NoError
+				trap.ErrorIndex = 0
+
+				// TODO: Check that the message marshalled is not too large
+				// for the originator to accept and if so, send a tooBig
+				// error PDU per RFC3416 section 4.2.7.  This maximum size,
+				// however, does not have a well-defined mechanism in the
+				// RFC other than using the path MTU (which is difficult to
+				// determine), so it's left to future implementations.
+				err := t.SendUDP(trap, remote)
+				if err != nil {
+					t.Params.Logger.Printf("TrapListener: %s\n", err)
 				}
 			}
 		}
 	}
+}
+
+func (t *TrapListener) reportAuthoritativeEngineID(trap *SnmpPacket, snmpEngineID string, addr *net.UDPAddr) error {
+	newSecurityParams, ok := trap.SecurityParameters.Copy().(*UsmSecurityParameters)
+	if !ok {
+		return errors.New("unable to cast SecurityParams to UsmSecurityParameters")
+	}
+	newSecurityParams.AuthoritativeEngineID = snmpEngineID
+	reportPacket := trap
+	reportPacket.PDUType = Report
+	reportPacket.MsgFlags &= AuthPriv
+	reportPacket.SecurityParameters = newSecurityParams
+	reportPacket.Variables = []SnmpPDU{
+		{
+			Name:  ".1.3.6.1.6.3.15.1.1.4.0",
+			Value: 1,
+			Type:  Integer,
+		},
+	}
+	return t.SendUDP(reportPacket, addr)
 }
 
 func (t *TrapListener) handleTCPRequest(conn net.Conn) {
@@ -269,13 +323,14 @@ func (t *TrapListener) handleTCPRequest(conn net.Conn) {
 	}
 
 	msg := buf[:reqLen]
-	traps := t.Params.UnmarshalTrap(msg, false)
-
-	if traps != nil {
-		// TODO: lying for backward compatibility reason - create UDP Address ... not nice
-		r, _ := net.ResolveUDPAddr("", conn.RemoteAddr().String())
-		t.OnNewTrap(traps, r)
+	traps, err := t.Params.UnmarshalTrap(msg, false)
+	if err != nil {
+		t.Params.Logger.Printf("TrapListener: error in read %s\n", err)
+		return
 	}
+	// TODO: lying for backward compatibility reason - create UDP Address ... not nice
+	r, _ := net.ResolveUDPAddr("", conn.RemoteAddr().String())
+	t.OnNewTrap(traps, r)
 	// Close the connection when you're done with it.
 	conn.Close()
 }
@@ -360,13 +415,13 @@ func (t *TrapListener) debugTrapHandler(s *SnmpPacket, u *net.UDPAddr) {
 // UnmarshalTrap unpacks the SNMP Trap.
 //
 // NOTE: the trap code is currently unreliable when working with snmpv3 - pull requests welcome
-func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket) {
+func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket, err error) {
 	result = new(SnmpPacket)
 
 	if x.SecurityParameters != nil {
-		err := x.SecurityParameters.initSecurityKeys()
+		err = x.SecurityParameters.initSecurityKeys()
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		result.SecurityParameters = x.SecurityParameters.Copy()
 	}
@@ -374,7 +429,7 @@ func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) 
 	cursor, err := x.unmarshalHeader(trap, result)
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap: %s\n", err)
-		return nil
+		return nil, err
 	}
 
 	if result.Version == Version3 {
@@ -382,20 +437,20 @@ func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) 
 			err = x.testAuthentication(trap, result, useResponseSecurityParameters)
 			if err != nil {
 				x.Logger.Printf("UnmarshalTrap v3 auth: %s\n", err)
-				return nil
+				return nil, err
 			}
 		}
 
 		trap, cursor, err = x.decryptPacket(trap, cursor, result)
 		if err != nil {
 			x.Logger.Printf("UnmarshalTrap v3 decrypt: %s\n", err)
-			return nil
+			return nil, err
 		}
 	}
 	err = x.unmarshalPayload(trap, cursor, result)
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap: %s\n", err)
-		return nil
+		return nil, err
 	}
-	return result
+	return result, nil
 }

--- a/trap_test.go
+++ b/trap_test.go
@@ -14,6 +14,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -63,7 +65,7 @@ SANITY:
 		Default.SecurityParameters = test.out.SecurityParameters.Copy()
 		Default.Version = Version3
 		var buf = test.in()
-		var res = Default.UnmarshalTrap(buf, true)
+		res, _ := Default.UnmarshalTrap(buf, true)
 		if res == nil {
 			t.Errorf("#%d, UnmarshalTrap returned nil", i)
 			continue SANITY
@@ -1229,4 +1231,77 @@ func TestSendV3TrapSHAAuthAES256CPriv(t *testing.T) {
 		t.Fatal("timed out waiting for trap to be received")
 	}
 
+}
+
+func TestSendV3EngineIdDiscovery(t *testing.T) {
+	tl := NewTrapListener()
+	defer tl.Close()
+	authorativeEngineID := string([]byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04})
+	unknownEngineID := string([]byte{0x80, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x05})
+	sp := &UsmSecurityParameters{
+		UserName:                 "test",
+		AuthenticationProtocol:   SHA,
+		AuthenticationPassphrase: "password",
+		PrivacyProtocol:          AES256,
+		PrivacyPassphrase:        "password",
+		AuthoritativeEngineBoots: 1,
+		AuthoritativeEngineTime:  1,
+		AuthoritativeEngineID:    authorativeEngineID,
+	}
+	tl.Params = Default
+	tl.Params.Version = Version3
+	tl.Params.SecurityParameters = sp
+	tl.Params.SecurityModel = UserSecurityModel
+	tl.Params.MsgFlags = AuthPriv
+
+	// listener goroutine
+	errch := make(chan error)
+	go func() {
+		err := tl.Listen(net.JoinHostPort(trapTestAddress, trapTestPortString))
+		if err != nil {
+			errch <- err
+		}
+	}()
+
+	// Wait until the listener is ready.
+	select {
+	case <-tl.Listening():
+	case err := <-errch:
+		t.Fatalf("error in listen: %v", err)
+	}
+
+	ts := &GoSNMP{
+		Target: trapTestAddress,
+		Port:   trapTestPort,
+		//Community: "public",
+		Version:            Version3,
+		Timeout:            time.Duration(2) * time.Second,
+		Retries:            3,
+		MaxOids:            MaxOids,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: sp,
+		MsgFlags:           AuthPriv,
+	}
+
+	err := ts.Connect()
+	if err != nil {
+		t.Fatalf("Connect() err: %v", err)
+	}
+	defer ts.Conn.Close()
+
+	getEngineIDRequest := SnmpPacket{
+		Version:            Version3,
+		MsgFlags:           Reportable,
+		SecurityModel:      UserSecurityModel,
+		SecurityParameters: &UsmSecurityParameters{},
+		ContextEngineID:    unknownEngineID,
+		PDUType:            GetRequest,
+		MsgID:              1824792385,
+		RequestID:          1411852680,
+		MsgMaxSize:         65507,
+	}
+	result, err := ts.sendOneRequest(&getEngineIDRequest, true)
+	require.NoError(t, err, "sendOneRequest failed")
+	require.Equal(t, result.SecurityParameters.(*UsmSecurityParameters).AuthoritativeEngineID, authorativeEngineID, "invalid authoritativeEngineID")
+	require.Equal(t, result.PDUType, Report, "invalid received PDUType")
 }

--- a/trap_test.go
+++ b/trap_test.go
@@ -65,7 +65,8 @@ SANITY:
 		Default.SecurityParameters = test.out.SecurityParameters.Copy()
 		Default.Version = Version3
 		var buf = test.in()
-		res, _ := Default.UnmarshalTrap(buf, true)
+		res, err := Default.UnmarshalTrap(buf, true)
+		require.NoError(t, err, "unmarshalTrap failed")
 		if res == nil {
 			t.Errorf("#%d, UnmarshalTrap returned nil", i)
 			continue SANITY


### PR DESCRIPTION
Hello 👋
When sending INFORMs, the sender may attempt to autodiscover the engineID of the receiving agent. Currently gosnmp does not answer to such requests, this PR is an attempt to fix that using [RFC3414](https://www.rfc-editor.org/rfc/rfc3414#section-3.2).

### Example
1. Run the example trapListener
2. Send an inform with snmptrapd like so:
```
snmptrap -v3 -Ci -l authPriv -u user -a SHA -A password -x AES -X password 127.0.0.1:9162 ''  1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 60
```

snmptrapd will first attempt to discover the engineID of the receiver by sending an empty GetRequest PDU (no variable, no authoritativeEngineId).

A compliant implementation should listen for this request and return a Report PDU with the correct authoritativeEngineID.

Because gosnmp does not yet answer to these requests, snmptrapd retries sending the same request multiple times until time-ing out and never actually sending the inform.

### How to test
The PR is unit tested. A good way to have a real-life test is to run the previous `snmptrapd` command with the new implementation. Now the discovery process succeeds and the inform is sent.