### PR TITLE
SendTrap: do not set Reportable MsgFlags for v3 trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,15 @@
 
 NOTE: The UnmarshalTrap now returns both an SnmpPacket and an error (#394)
 
+* [BUGFIX] SendTrap: do not set Reportable MsgFlags for v3 #398
 * [CHANGE] Support authoritative engineID discovery when listening for traps #394
+* [ENHANCEMENT] marshalUint32: Values above 2^31-1 encodes in 5 bytes #377
 
 * [CHANGE]
 * [FEATURE]
 * [ENHANCEMENT]
 * [BUGFIX]
 
-## Unreleased
-
-* [ENHANCEMENT] marshalUint32: Values above 2^31-1 encodes in 5 bytes #377
 
 ## v1.34.0
 

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -356,6 +356,8 @@ func (x *GoSNMP) validateParameters() error {
 	}
 
 	if x.Version == Version3 {
+		// TODO: setting the Reportable flag violates rfc3412#6.4 if PDU is of type SNMPv2Trap.
+		// See if we can do this smarter and remove bitclear fix from trap.go:57
 		x.MsgFlags |= Reportable // tell the snmp server that a report PDU MUST be sent
 
 		err := x.validateParametersV3()

--- a/trap.go
+++ b/trap.go
@@ -49,6 +49,16 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 		// Default to a v2 trap.
 		pdutype = SNMPv2Trap
 
+		switch x.MsgFlags {
+		// as per https://www.rfc-editor.org/rfc/rfc3412.html#section-6.4
+		// The reportableFlag MUST always be zero when the message contains
+		// a PDU from the Unconfirmed Class such as an SNMPv2-trap PDU
+		case 0x4, 0x5, 0x7:
+			// .. therefor bitclear the Reportable flag from the MsgFlags
+			// that we inherited from validateParameters()
+			x.MsgFlags = (x.MsgFlags &^ Reportable)
+		}
+
 		// If it's an inform, do that instead.
 		if trap.IsInform {
 			pdutype = InformRequest


### PR DESCRIPTION
* SendTrap: do not set Reportable MsgFlags for v3 trap as per rfc3412#6.4

Fixes: #391

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>