### PR TITLE
generic_e2e_test.go: Improve SnmpV3 tests

### DIFF
--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -403,6 +403,34 @@ func TestSnmpV3AuthMD5NoPrivGet(t *testing.T) {
 	}
 }
 
+func TestSnmpV3AuthMD5PrivAES192Get(t *testing.T) {
+	Default.Version = Version3
+	Default.MsgFlags = AuthPriv
+	Default.SecurityModel = UserSecurityModel
+	Default.SecurityParameters = &UsmSecurityParameters{
+		UserName:               getUserName(t, MD5, AES192),
+		AuthenticationProtocol: MD5, AuthenticationPassphrase: getAuthKey(t, MD5, AES192),
+		PrivacyProtocol: AES192, PrivacyPassphrase: getPrivKey(t, MD5, AES192),
+	}
+	setupConnection(t)
+	defer Default.Conn.Close()
+
+	result, err := Default.Get([]string{".1.3.6.1.2.1.1.1.0"}) // SNMP MIB-2 sysDescr
+	if err != nil {
+		t.Fatalf("Get() failed with error => %v", err)
+	}
+	if len(result.Variables) != 1 {
+		t.Fatalf("Expected result of size 1")
+	}
+	if result.Variables[0].Type != OctetString {
+		t.Fatalf("Expected sysDescr to be OctetString")
+	}
+	sysDescr := result.Variables[0].Value.([]byte)
+	if len(sysDescr) == 0 {
+		t.Fatalf("Got a zero length sysDescr")
+	}
+}
+
 func TestSnmpV3AuthMD5PrivAES256CGet(t *testing.T) {
 	if !isUsingSnmpLabs() {
 		t.Skip("This test is currently only working when using demo.snmplabs.com as test device.")

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -660,7 +660,6 @@ func TestSnmpV3AuthSHA512NoPrivGet(t *testing.T) {
 }
 
 func TestSnmpV3AuthSHA512PrivAES192Get(t *testing.T) {
-	t.Skip("AES-192 Blumenthal is currently known to have issues.")
 	Default.Version = Version3
 	Default.MsgFlags = AuthPriv
 	Default.SecurityModel = UserSecurityModel

--- a/snmp_users.sh
+++ b/snmp_users.sh
@@ -23,6 +23,8 @@ createUser authSHA256PrivAESUser SHA256 testingpass7223456 AES
 createUser authSHA384PrivAESUser SHA384 testingpass7323456 AES
 createUser authSHA512PrivAESUser SHA512 testingpass7423456 AES
 
+createUser authMD5PrivAES192BlmtUser MD5 "authkey1" AES-192 "privkey1"
+
 rouser   noAuthNoPrivUser noauth
 rouser   authMD5OnlyUser auth
 rouser   authSHAOnlyUser auth
@@ -44,6 +46,8 @@ rouser   authSHA224PrivAESUser authPriv
 rouser   authSHA256PrivAESUser authPriv
 rouser   authSHA384PrivAESUser authPriv
 rouser   authSHA512PrivAESUser authPriv
+
+rouser   authMD5PrivAES192BlmtUser authPriv
 EOF
 
 # enable ipv6 TODO restart fails - need to enable ipv6 on interface; spin up a Linux instance to check this

--- a/snmp_users.sh
+++ b/snmp_users.sh
@@ -23,7 +23,8 @@ createUser authSHA256PrivAESUser SHA256 testingpass7223456 AES
 createUser authSHA384PrivAESUser SHA384 testingpass7323456 AES
 createUser authSHA512PrivAESUser SHA512 testingpass7423456 AES
 
-createUser authMD5PrivAES192BlmtUser MD5 "authkey1" AES-192 "privkey1"
+createUser authMD5PrivAES192BlmtUser MD5 authkey1 AES-192 privkey1
+createUser authSHA512PrivAES192BlmtUser SHA512 authkey1 AES-192 privkey1
 
 rouser   noAuthNoPrivUser noauth
 rouser   authMD5OnlyUser auth
@@ -48,6 +49,7 @@ rouser   authSHA384PrivAESUser authPriv
 rouser   authSHA512PrivAESUser authPriv
 
 rouser   authMD5PrivAES192BlmtUser authPriv
+rouser   authSHA512PrivAES192BlmtUser authPriv
 EOF
 
 # enable ipv6 TODO restart fails - need to enable ipv6 on interface; spin up a Linux instance to check this

--- a/v3_credentials_test.go
+++ b/v3_credentials_test.go
@@ -50,7 +50,7 @@ var authenticationCredentials = map[string][]string{
 	SHA512.String() + NoPriv.String(): {"authSHA512OnlyUser", "testingpass5423456", ""},
 	SHA512.String() + DES.String():    {"authSHA512PrivDESUser", "testingpass6423456", "testingpass6423456"},
 	SHA512.String() + AES.String():    {"authSHA512PrivAESUser", "testingpass7423456", "testingpass7423456"},
-	// SHA512.String() + AES192.String():	{ "authSHA512PrivAES192BlmtUser", "authkey1", "privkey1" },
+	SHA512.String() + AES192.String(): {"authSHA512PrivAES192BlmtUser", "authkey1", "privkey1"},
 	// SHA512.String() + AES192C.String():	{ "authSHA512PrivAES192User", "authkey1", "privkey1" },
 	// SHA512.String() + AES256.String():	{ "authSHA512PrivAES256BlmtUser", "authkey1", "privkey1" },
 	// SHA512.String() + AES256C.String():	{ "authSHA512PrivAES256User", "authkey1", "privkey1" },

--- a/v3_credentials_test.go
+++ b/v3_credentials_test.go
@@ -10,7 +10,7 @@ var authenticationCredentials = map[string][]string{
 	MD5.String() + NoPriv.String(): {"authMD5OnlyUser", "testingpass0123456789", ""},
 	MD5.String() + DES.String():    {"authMD5PrivDESUser", "testingpass9876543210", "testingpass9876543210"},
 	MD5.String() + AES.String():    {"authMD5PrivAESUser", "AEStestingpass9876543210", "AEStestingpass9876543210"},
-	// MD5.String() + AES192.String():		{ "authMD5PrivAES192BlmtUser", "authkey1", "privkey1" },
+	MD5.String() + AES192.String(): {"authMD5PrivAES192BlmtUser", "authkey1", "privkey1"},
 	// MD5.String() + AES192C.String():	{ "authMD5PrivAES192User", "authkey1", "privkey1" },
 	// MD5.String() + AES256.String():		{ "authMD5PrivAES256BlmtUser", "authkey1", "privkey1" },
 	// MD5.String() + AES256C.String():	{ "authMD5PrivAES256User", "authkey1", "privkey1" },

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -484,7 +484,7 @@ func extendKeyBlumenthal(authProtocol SnmpV3AuthProtocol, password string, engin
 	var key []byte
 	var err error
 
-	key, err = hMAC(authProtocol.HashType(), cacheKey(authProtocol, ""), password, engineID)
+	key, err = hMAC(authProtocol.HashType(), cacheKey(authProtocol, password), password, engineID)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
*  Fix broken TestSnmpV3AuthSHA512PrivAES192Get caused by nil  passphrase in extendKeyBlumenthal cachekey generation.
*  Add TestSnmpV3AuthMD5PrivAES192Get test

Fixes: #395 

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>