### PR TITLE
gosnmp/circleci: run build tests on netsnmp 5.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
 
     steps:
     - checkout
+    - run: sudo sed -i 's/focal/impish/g' /etc/apt/sources.list
     - run: sudo apt-get update
     - run: sudo apt-get -y install snmpd
     - run: sudo ./snmp_users.sh


### PR DESCRIPTION
* .circleci/config.yml: update apt sources.list to use impish packages
which will result in pulling in net-snmp 5.9 based snmpd.

Unblocks SNMPv3 testing of AES ciphers in #399

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>