### PR TITLE
Update build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,15 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.17
+    - image: cimg/go:1.18
 
 jobs:
   generate:
     executor: golang
     steps:
     - checkout
-    - run: cd /tmp && go get golang.org/x/tools/cmd/stringer
-    - run: cd /tmp && go get github.com/golang/mock/mockgen
+    - run: go install golang.org/x/tools/cmd/stringer@latest
+    - run: go install github.com/golang/mock/mockgen@latest
     - run: go generate
     - run: git diff --exit-code
 
@@ -73,8 +73,5 @@ workflows:
             - "amd64"
             - "386"
             goversion:
-            - "1.13"
-            - "1.14"
-            - "1.15"
-            - "1.16"
             - "1.17"
+            - "1.18"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ NOTE: The UnmarshalTrap now returns both an SnmpPacket and an error (#394)
 
 * [BUGFIX] SendTrap: do not set Reportable MsgFlags for v3 #398
 * [CHANGE] Support authoritative engineID discovery when listening for traps #394
+* [CHANGE] Require Go 1.17+
 * [ENHANCEMENT] marshalUint32: Values above 2^31-1 encodes in 5 bytes #377
 
 * [CHANGE]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test lint lint-all lint-examples tools
 
+GOLANGCI_LINT_VERSION ?= v1.45.2
+
 test:
 	go test *.go
 
@@ -7,4 +9,5 @@ lint:
 	golangci-lint run -v
 
 tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin v1.42.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
+		| sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
 module github.com/gosnmp/gosnmp
 
-go 1.13
+go 1.17
 
 require (
 	github.com/golang/mock v1.6.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+Licev
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
* Update build for Go 1.18.
* Update Go modules for 1.17.
* Update golangci-lint to v1.45.2.
* Bump Go modules.

Signed-off-by: SuperQ <superq@gmail.com>