### PR TITLE
fix:getBulk SnmpPacket can not get right MaxRepetitions value

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1117,8 +1117,8 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("error parsing SNMP packet, packet length %d cursor %d", len(packet), cursor)
 		}
 
-		if maxRepetitions, ok := rawMaxRepetitions.(uint32); ok {
-			response.MaxRepetitions = (maxRepetitions & 0x7FFFFFFF)
+		if maxRepetitions, ok := rawMaxRepetitions.(int); ok {
+			response.MaxRepetitions = uint32(maxRepetitions & 0x7FFFFFFF)
 		}
 	} else {
 		// Parse Error-Status


### PR DESCRIPTION
unmarshal getBulk SnmpPacket ,can not get right MaxRepetitions value

when call parseRawField() , the packet Asn1BER type is Integer, then it will call parseInt() to parse MaxRepetitions. the parseInt() only return int type, but in marshal.go assert it as uint32,so you will get 0