### PR TITLE
Remove deprecated io/ioutil

### DIFF
--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -13,7 +13,7 @@
 package gosnmp_test // force external view
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"testing"
@@ -34,7 +34,7 @@ func TestAPIConfigTypes(t *testing.T) {
 	g.MaxOids = 0
 	g.MaxRepetitions = 0
 	g.NonRepeaters = 0
-	g.Logger = gosnmp.NewLogger(log.New(ioutil.Discard, "", 0))
+	g.Logger = gosnmp.NewLogger(log.New(io.Discard, "", 0))
 	var c net.Conn
 	c = g.Conn
 	_ = c

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"reflect"
@@ -270,7 +270,7 @@ func checkByteEquality(t *testing.T, test testsEnmarshalT, testBytes []byte,
 // ie check each varbind is working, then the varbind list, etc
 
 func TestEnmarshalVarbind(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 	for _, test := range testsEnmarshal {
 		for j, test2 := range test.vbPositions {
@@ -287,7 +287,7 @@ func TestEnmarshalVarbind(t *testing.T) {
 }
 
 func TestEnmarshalVBL(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 	for _, test := range testsEnmarshal {
 		x := &SnmpPacket{
@@ -307,7 +307,7 @@ func TestEnmarshalVBL(t *testing.T) {
 }
 
 func TestEnmarshalPDU(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 	for _, test := range testsEnmarshal {
 		x := &SnmpPacket{
@@ -328,7 +328,7 @@ func TestEnmarshalPDU(t *testing.T) {
 }
 
 func TestEnmarshalMsg(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 	for _, test := range testsEnmarshal {
 		x := &SnmpPacket{
@@ -732,7 +732,7 @@ var testsUnmarshal = []struct {
 }
 
 func TestUnmarshal(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 	for i, test := range testsUnmarshal {
 		funcName := runtime.FuncForPC(reflect.ValueOf(test.in).Pointer()).Name()
@@ -1389,7 +1389,7 @@ func TestUnmarshalEmptyPanic(t *testing.T) {
 }
 
 func TestV3USMInitialPacket(t *testing.T) {
-	logger := NewLogger(log.New(ioutil.Discard, "", 0))
+	logger := NewLogger(log.New(io.Discard, "", 0))
 	var emptyPdus []SnmpPDU
 	blankPacket := &SnmpPacket{
 		Version:            Version3,

--- a/trap_test.go
+++ b/trap_test.go
@@ -8,7 +8,7 @@
 package gosnmp
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"reflect"
@@ -50,14 +50,14 @@ var testsUnmarshalTrap = []struct {
 				UserName:                 "myuser",
 				AuthenticationProtocol:   MD5,
 				AuthenticationPassphrase: "mypassword",
-				Logger:                   NewLogger(log.New(ioutil.Discard, "", 0)),
+				Logger:                   NewLogger(log.New(io.Discard, "", 0)),
 			},
 		},
 	},
 }
 
 func TestUnmarshalTrap(t *testing.T) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 
 SANITY:
 	for i, test := range testsUnmarshalTrap {
@@ -107,7 +107,7 @@ func genericV3Trap() []byte {
 }
 
 func makeTestTrapHandler(t *testing.T, done chan int, version SnmpVersion) func(*SnmpPacket, *net.UDPAddr) {
-	Default.Logger = NewLogger(log.New(ioutil.Discard, "", 0))
+	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
 	return func(packet *SnmpPacket, addr *net.UDPAddr) {
 		//log.Printf("got trapdata from %s\n", addr.IP)
 		defer close(done)
@@ -194,7 +194,7 @@ func TestSendTrapBasic(t *testing.T) {
 		Timeout:   time.Duration(2) * time.Second,
 		Retries:   3,
 		MaxOids:   MaxOids,
-		Logger:    NewLogger(log.New(ioutil.Discard, "", 0)),
+		Logger:    NewLogger(log.New(io.Discard, "", 0)),
 	}
 
 	err := ts.Connect()

--- a/v3_usm_test.go
+++ b/v3_usm_test.go
@@ -2,7 +2,7 @@ package gosnmp
 
 import (
 	"encoding/hex"
-	"io/ioutil"
+	"io"
 	"log"
 	"testing"
 
@@ -66,7 +66,7 @@ func TestAuthenticationSHA224(t *testing.T) {
 		AuthenticationPassphrase: "authkey1",
 		PrivacyPassphrase:        "",
 		SecretKey:                nil,
-		Logger:                   NewLogger(log.New(ioutil.Discard, "", 0)),
+		Logger:                   NewLogger(log.New(io.Discard, "", 0)),
 		PrivacyKey:               nil,
 	}
 
@@ -102,7 +102,7 @@ func TestIsAuthenticaSHA224(t *testing.T) {
 		PrivacyPassphrase:        "",
 		SecretKey:                nil,
 		PrivacyKey:               nil,
-		Logger:                   NewLogger(log.New(ioutil.Discard, "", 0)),
+		Logger:                   NewLogger(log.New(io.Discard, "", 0)),
 	}
 
 	sp.SecretKey, err = genlocalkey(sp.AuthenticationProtocol,
@@ -169,7 +169,7 @@ func TestAuthenticationSHA512(t *testing.T) {
 		PrivacyPassphrase:        "",
 		SecretKey:                nil,
 		PrivacyKey:               nil,
-		Logger:                   NewLogger(log.New(ioutil.Discard, "", 0)),
+		Logger:                   NewLogger(log.New(io.Discard, "", 0)),
 	}
 
 	sp.SecretKey, err = genlocalkey(sp.AuthenticationProtocol,
@@ -203,7 +203,7 @@ func TestIsAuthenticaSHA512(t *testing.T) {
 		AuthenticationPassphrase: "authkey1",
 		PrivacyPassphrase:        "",
 		SecretKey:                nil,
-		Logger:                   NewLogger(log.New(ioutil.Discard, "", 0)),
+		Logger:                   NewLogger(log.New(io.Discard, "", 0)),
 		PrivacyKey:               nil,
 	}
 


### PR DESCRIPTION
Go 1.16 deprecated io/ioutil. Replace with new functions.

Signed-off-by: SuperQ <superq@gmail.com>