### PR TITLE
Update Go testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.19
+    - image: cimg/go:1.20
 
 jobs:
   generate:
@@ -76,3 +76,4 @@ workflows:
             - "1.17"
             - "1.18"
             - "1.19"
+            - "1.20"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,25 @@
 .PHONY: test lint lint-all lint-examples tools
 
-GOLANGCI_LINT_VERSION ?= v1.50.1
+GOLANGCI_LINT_VERSION ?= v1.51.2
 
 test:
 	go test *.go
 
-lint:
+lint: check_license
 	golangci-lint run -v
 
 tools:
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
 		| sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+
+.PHONY: check_license
+check_license:
+	@echo ">> checking license header"
+	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*') ; do \
+               awk 'NR<=3' $$file | grep -Eq "(Copyright [0-9]+ The GoSNMP Authors|generated|GENERATED)" || echo $$file; \
+       done); \
+       if [ -n "$${licRes}" ]; then \
+               echo "license header checking failed:"; echo "$${licRes}"; \
+               exit 1; \
+       fi
+

--- a/examples/tcp_trapserver/main.go
+++ b/examples/tcp_trapserver/main.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
 package main
 
 import (

--- a/logger.go
+++ b/logger.go
@@ -1,3 +1,7 @@
+// Copyright 2021 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
 //go:build gosnmp_nodebug
 // +build gosnmp_nodebug
 

--- a/logger_debug.go
+++ b/logger_debug.go
@@ -1,3 +1,7 @@
+// Copyright 2021 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
 //go:build !gosnmp_nodebug
 // +build !gosnmp_nodebug
 

--- a/v3_credentials_test.go
+++ b/v3_credentials_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
 package gosnmp
 
 import "testing"

--- a/v3_usm_test.go
+++ b/v3_usm_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
 package gosnmp
 
 import (


### PR DESCRIPTION
* Add Go 1.20 to tests.
* Add a Makefile linter for the license header.