### PR TITLE
Allow global password cache to be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ go get github.com/matm/gocov-html
 gocov test github.com/gosnmp/gosnmp | gocov-html > gosnmp.html && firefox gosnmp.html &
 ```
 
+To measure the performance of password hash caching:
+
+Password hash caching can be disabled during benchmark tests by using the golang build tag "gosnmp_nopwdcache", so:
+```
+go build -tags gosnmp_nopwdcache -bench=Benchmark.*Hash
+```
+will benchmark the code without password hash caching. Removing the tag will run the benchmark with caching enabled (default behavior of package).
+
 
 # License
 

--- a/v3_usm_nopwdcache_test.go
+++ b/v3_usm_nopwdcache_test.go
@@ -1,0 +1,11 @@
+// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+//go:build nopwdcache
+
+package gosnmp
+
+func SetPwdCache() {
+	PasswordCaching(false)
+}

--- a/v3_usm_nopwdcache_test.go
+++ b/v3_usm_nopwdcache_test.go
@@ -2,7 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
-//go:build nopwdcache
+//go:build gosnmp_nopwdcache
 
 package gosnmp
 

--- a/v3_usm_pwdcache_test.go
+++ b/v3_usm_pwdcache_test.go
@@ -1,0 +1,11 @@
+// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+//go:build !nopwdcache
+
+package gosnmp
+
+func SetPwdCache() {
+	PasswordCaching(true)
+}

--- a/v3_usm_pwdcache_test.go
+++ b/v3_usm_pwdcache_test.go
@@ -2,7 +2,7 @@
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
-//go:build !nopwdcache
+//go:build !gosnmp_nopwdcache
 
 package gosnmp
 

--- a/v3_usm_test.go
+++ b/v3_usm_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -231,9 +230,7 @@ func TestIsAuthenticaSHA512(t *testing.T) {
 }
 
 func BenchmarkSingleHash(b *testing.B) {
-	if len(os.Getenv("NOPWDCACHE")) > 0 {
-		PasswordCaching(false)
-	}
+	SetPwdCache()
 
 	engineID, _ := hex.DecodeString("80004fb805636c6f75644dab22cc")
 


### PR DESCRIPTION
The global password cache is undesirable for higher security applications as a user's cache entry would remain even if the calling package deleted the corresponding `UsmSecurityParameters`.

Disabling this mechanism comes with a significant performance hit, as seen by running the added benchmark tests with the build tag `gosnmp_nopwdcache`.

There is also a middle ground approach, where the calling package can reset the cache by turning it off then on again. This should clear any stale entries and still allow the cache to be leveraged.