### PR TITLE
Support multiple security parameters for receiving SNMP V3 traps

### DIFF
--- a/examples/trapserver_v3/main.go
+++ b/examples/trapserver_v3/main.go
@@ -1,4 +1,4 @@
-// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2023 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -62,16 +62,19 @@ func main() {
 
 	usmTable := g.NewSnmpV3SecurityParametersTable()
 	for _, sp := range secParamsList {
-		usmTable.Add(sp.UserName, sp)
+		err := usmTable.Add(sp.UserName, sp)
+		if err != nil {
+			sp.Logger.Print(err)
+		}
 	}
 
 	gs := &g.GoSNMP{
-		Port:                    161,
-		Transport:               "udp",
-		Version:                 g.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
-		SecurityModel:           g.UserSecurityModel,
-		SecurityParameters:      &g.UsmSecurityParameters{AuthoritativeEngineID: "12345"}, // Use for server's engine ID
-		SecurityParametersTable: usmTable,
+		Port:                        161,
+		Transport:                   "udp",
+		Version:                     g.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
+		SecurityModel:               g.UserSecurityModel,
+		SecurityParameters:          &g.UsmSecurityParameters{AuthoritativeEngineID: "12345"}, // Use for server's engine ID
+		TrapSecurityParametersTable: usmTable,
 	}
 	tl.Params = gs
 	tl.Params.Logger = g.NewLogger(log.New(os.Stdout, "", 0))

--- a/examples/trapserver_v3/main.go
+++ b/examples/trapserver_v3/main.go
@@ -1,0 +1,89 @@
+// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+/*
+The developer of the trapserver code (https://github.com/jda) says "I'm working
+on the best level of abstraction but I'm able to receive traps from a Cisco
+switch and Net-SNMP".
+
+Pull requests welcome.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+
+	g "github.com/gosnmp/gosnmp"
+)
+
+var (
+	sp = g.UsmSecurityParameters{
+		UserName:                 "myuser",
+		AuthenticationProtocol:   g.MD5,
+		AuthenticationPassphrase: "mypassword",
+		PrivacyProtocol:          g.AES,
+		PrivacyPassphrase:        "myprivacy",
+		Logger:                   g.NewLogger(log.New(os.Stdout, "", 0)),
+	}
+	sp2 = g.UsmSecurityParameters{
+		UserName:                 "myuser2",
+		AuthenticationProtocol:   g.SHA,
+		AuthenticationPassphrase: "mypassword2",
+		PrivacyProtocol:          g.DES,
+		PrivacyPassphrase:        "myprivacy2",
+		Logger:                   g.NewLogger(log.New(os.Stdout, "", 0)),
+	}
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("Usage:\n")
+		fmt.Printf("   %s\n", filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+
+	tl := g.NewTrapListener()
+	tl.OnNewTrap = myTrapHandler
+
+	usmMap := make(map[string]g.SnmpV3SecurityParameters)
+	usmMap["myuser"] = &sp
+	usmMap["myuser2"] = &sp2
+
+	gs := &g.GoSNMP{
+		Port:                      161,
+		Transport:                 "udp",
+		Version:                   g.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
+		SecurityModel:             g.UserSecurityModel,
+		SecurityParameters:        &sp,
+		UserSecurityParametersMap: usmMap,
+	}
+	tl.Params = gs
+
+	tl.Params.Logger = g.NewLogger(log.New(os.Stdout, "", 0))
+
+	err := tl.Listen("0.0.0.0:9162")
+	if err != nil {
+		log.Panicf("error in listen: %s", err)
+	}
+}
+
+func myTrapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
+	log.Printf("got trapdata from %s\n", addr.IP)
+	for _, v := range packet.Variables {
+		switch v.Type {
+		case g.OctetString:
+			b := v.Value.([]byte)
+			fmt.Printf("OID: %s, string: %x\n", v.Name, b)
+
+		default:
+			log.Printf("trap: %+v\n", v)
+		}
+	}
+}

--- a/examples/trapserver_v3/main.go
+++ b/examples/trapserver_v3/main.go
@@ -24,29 +24,26 @@ import (
 )
 
 var secParamsList = []*g.UsmSecurityParameters{
-	&g.UsmSecurityParameters{
+	{
 		UserName:                 "myuser",
 		AuthenticationProtocol:   g.MD5,
 		AuthenticationPassphrase: "mypassword",
 		PrivacyProtocol:          g.AES,
 		PrivacyPassphrase:        "myprivacy",
-		Logger:                   g.NewLogger(log.New(os.Stdout, "", 0)),
 	},
-	&g.UsmSecurityParameters{
+	{
 		UserName:                 "myuser2",
 		AuthenticationProtocol:   g.SHA,
 		AuthenticationPassphrase: "mypassword2",
 		PrivacyProtocol:          g.DES,
 		PrivacyPassphrase:        "myprivacy2",
-		Logger:                   g.NewLogger(log.New(os.Stdout, "", 0)),
 	},
-	&g.UsmSecurityParameters{
+	{
 		UserName:                 "myuser2",
 		AuthenticationProtocol:   g.MD5,
 		AuthenticationPassphrase: "mypassword2",
 		PrivacyProtocol:          g.AES,
 		PrivacyPassphrase:        "myprivacy2",
-		Logger:                   g.NewLogger(log.New(os.Stdout, "", 0)),
 	},
 }
 
@@ -60,11 +57,11 @@ func main() {
 	tl := g.NewTrapListener()
 	tl.OnNewTrap = myTrapHandler
 
-	usmTable := g.NewSnmpV3SecurityParametersTable()
+	usmTable := g.NewSnmpV3SecurityParametersTable(g.NewLogger(log.New(os.Stdout, "", 0)))
 	for _, sp := range secParamsList {
 		err := usmTable.Add(sp.UserName, sp)
 		if err != nil {
-			sp.Logger.Print(err)
+			usmTable.Logger.Print(err)
 		}
 	}
 

--- a/examples/trapserver_v3/main.go
+++ b/examples/trapserver_v3/main.go
@@ -60,18 +60,18 @@ func main() {
 	tl := g.NewTrapListener()
 	tl.OnNewTrap = myTrapHandler
 
-	usmMap := g.NewSnmpV3SecurityParametersMap()
+	usmTable := g.NewSnmpV3SecurityParametersTable()
 	for _, sp := range secParamsList {
-		usmMap.AddEntry(sp.UserName, sp)
+		usmTable.Add(sp.UserName, sp)
 	}
 
 	gs := &g.GoSNMP{
-		Port:                  161,
-		Transport:             "udp",
-		Version:               g.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
-		SecurityModel:         g.UserSecurityModel,
-		SecurityParameters:    secParamsList[0],
-		SecurityParametersMap: usmMap,
+		Port:                    161,
+		Transport:               "udp",
+		Version:                 g.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
+		SecurityModel:           g.UserSecurityModel,
+		SecurityParameters:      &g.UsmSecurityParameters{AuthoritativeEngineID: "12345"}, // Use for server's engine ID
+		SecurityParametersTable: usmTable,
 	}
 	tl.Params = gs
 	tl.Params.Logger = g.NewLogger(log.New(os.Stdout, "", 0))

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -156,8 +156,8 @@ type GoSNMP struct {
 	// SecurityParameters is an SNMPV3 Security Model parameters struct.
 	SecurityParameters SnmpV3SecurityParameters
 
-	// UserSecurityParametersMap is a mapping of usernames to corresponding SNMP V3 Security Model parameters
-	UserSecurityParametersMap UserSecurityParametersMap
+	// SecurityParametersMap is a mapping of identifiers to corresponding SNMP V3 Security Model parameters
+	SecurityParametersMap SnmpV3SecurityParametersMap
 
 	// ContextEngineID is SNMPV3 ContextEngineID in ScopedPDU.
 	ContextEngineID string

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -156,8 +156,8 @@ type GoSNMP struct {
 	// SecurityParameters is an SNMPV3 Security Model parameters struct.
 	SecurityParameters SnmpV3SecurityParameters
 
-	// SecurityParametersMap is a mapping of identifiers to corresponding SNMP V3 Security Model parameters
-	SecurityParametersMap SnmpV3SecurityParametersMap
+	// SecurityParametersTable is a mapping of identifiers to corresponding SNMP V3 Security Model parameters
+	SecurityParametersTable *SnmpV3SecurityParametersTable
 
 	// ContextEngineID is SNMPV3 ContextEngineID in ScopedPDU.
 	ContextEngineID string

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -156,8 +156,9 @@ type GoSNMP struct {
 	// SecurityParameters is an SNMPV3 Security Model parameters struct.
 	SecurityParameters SnmpV3SecurityParameters
 
-	// SecurityParametersTable is a mapping of identifiers to corresponding SNMP V3 Security Model parameters
-	SecurityParametersTable *SnmpV3SecurityParametersTable
+	// TrapSecurityParametersTable is a mapping of identifiers to corresponding SNMP V3 Security Model parameters
+	// right now only supported for receiving traps, variable name to make that clear
+	TrapSecurityParametersTable *SnmpV3SecurityParametersTable
 
 	// ContextEngineID is SNMPV3 ContextEngineID in ScopedPDU.
 	ContextEngineID string

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -156,6 +156,9 @@ type GoSNMP struct {
 	// SecurityParameters is an SNMPV3 Security Model parameters struct.
 	SecurityParameters SnmpV3SecurityParameters
 
+	// UserSecurityParametersMap is a mapping of usernames to corresponding SNMP V3 Security Model parameters
+	UserSecurityParametersMap UserSecurityParametersMap
+
 	// ContextEngineID is SNMPV3 ContextEngineID in ScopedPDU.
 	ContextEngineID string
 

--- a/marshal.go
+++ b/marshal.go
@@ -979,7 +979,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 
 // -- Unmarshalling Logic ------------------------------------------------------
 
-func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket) (int, SnmpVersion, error) {
+func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket) (SnmpVersion, int, error) {
 	if len(packet) < 2 {
 		return 0, 0, fmt.Errorf("cannot unmarshal empty packet")
 	}
@@ -1019,13 +1019,13 @@ func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket)
 
 	if version, ok := rawVersion.(int); ok {
 		x.Logger.Printf("Parsed version %d", version)
-		return cursor, SnmpVersion(version), nil
+		return SnmpVersion(version), cursor, nil
 	}
-	return cursor, 0, err
+	return 0, cursor, err
 }
 
 func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, error) {
-	cursor, version, err := x.unmarshalVersionFromHeader(packet, response)
+	version, cursor, err := x.unmarshalVersionFromHeader(packet, response)
 	if err != nil {
 		return 0, err
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -979,7 +979,7 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 
 // -- Unmarshalling Logic ------------------------------------------------------
 
-func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, error) {
+func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket) (int, error) {
 	if len(packet) < 2 {
 		return 0, fmt.Errorf("cannot unmarshal empty packet")
 	}
@@ -1020,6 +1020,14 @@ func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, erro
 	if version, ok := rawVersion.(int); ok {
 		response.Version = SnmpVersion(version)
 		x.Logger.Printf("Parsed version %d", version)
+	}
+	return cursor, err
+}
+
+func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, error) {
+	cursor, err := x.unmarshalVersionFromHeader(packet, response)
+	if err != nil {
+		return 0, err
 	}
 
 	if response.Version == Version3 {

--- a/trap.go
+++ b/trap.go
@@ -442,9 +442,8 @@ func (t *TrapListener) debugTrapHandler(s *SnmpPacket, u *net.UDPAddr) {
 
 // UnmarshalTrap unpacks the SNMP Trap.
 func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket, err error) {
-	result = new(SnmpPacket)
 	// Get only the version from the header of the trap
-	_, version, err := x.unmarshalVersionFromHeader(trap, result)
+	version, _, err := x.unmarshalVersionFromHeader(trap, new(SnmpPacket))
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap version unmarshal: %s\n", err)
 		return nil, err

--- a/trap.go
+++ b/trap.go
@@ -444,41 +444,35 @@ func (t *TrapListener) debugTrapHandler(s *SnmpPacket, u *net.UDPAddr) {
 func (x *GoSNMP) UnmarshalTrap(trap []byte, useResponseSecurityParameters bool) (result *SnmpPacket, err error) {
 	result = new(SnmpPacket)
 	// Get only the version from the header of the trap
-	_, err = x.unmarshalVersionFromHeader(trap, result)
+	_, version, err := x.unmarshalVersionFromHeader(trap, result)
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap version unmarshal: %s\n", err)
 		return nil, err
 	}
 	// If there are multiple users configured and the SNMP trap is v3, see which user has valid credentials
 	// by iterating through the list matching the identifier and seeing which credentials are authentic / can be used to decrypt
-	if x.SecurityParametersTable != nil && result.Version == Version3 {
+	if x.TrapSecurityParametersTable != nil && version == Version3 {
 		identifier, err := x.getTrapIdentifier(trap)
 		if err != nil {
 			x.Logger.Printf("UnmarshalTrap V3 get trap identifier: %s\n", err)
 			return nil, err
 		}
-		secParamsList, err := x.SecurityParametersTable.Get(identifier)
+		secParamsList, err := x.TrapSecurityParametersTable.Get(identifier)
 		if err != nil {
 			x.Logger.Printf("UnmarshalTrap V3 get security parameters from table: %s\n", err)
 			return nil, err
 		}
 		for _, secParams := range secParamsList {
-			// Copy the trap and re-initialize the packet with new security parameters to unmarshal with
+			// Copy the trap and pass the security parameters to try to unmarshal with
 			cpTrap := make([]byte, len(trap))
 			copy(cpTrap, trap)
-			result = new(SnmpPacket)
-			if err = secParams.InitSecurityKeys(); err != nil {
-				return nil, err
-			}
-			result.SecurityParameters = secParams.Copy()
-			err = x.UnmarshalTrapBase(cpTrap, result, true)
-			if err == nil {
-				return result, err
+			if result, err = x.unmarshalTrapBase(cpTrap, secParams.Copy(), true); err == nil {
+				return result, nil
 			}
 		}
 		return nil, fmt.Errorf("no credentials successfully unmarshaled trap: %w", err)
 	}
-	return result, x.UnmarshalTrapBase(trap, result, useResponseSecurityParameters)
+	return x.unmarshalTrapBase(trap, nil, useResponseSecurityParameters)
 }
 
 func (x *GoSNMP) getTrapIdentifier(trap []byte) (string, error) {
@@ -492,19 +486,23 @@ func (x *GoSNMP) getTrapIdentifier(trap []byte) (string, error) {
 	return packet.SecurityParameters.getIdentifier(), nil
 }
 
-func (x *GoSNMP) UnmarshalTrapBase(trap []byte, result *SnmpPacket, useResponseSecurityParameters bool) error {
-	if x.SecurityParameters != nil && result.SecurityParameters == nil {
+func (x *GoSNMP) unmarshalTrapBase(trap []byte, sp SnmpV3SecurityParameters, useResponseSecurityParameters bool) (*SnmpPacket, error) {
+	result := new(SnmpPacket)
+
+	if x.SecurityParameters != nil && sp == nil {
 		err := x.SecurityParameters.InitSecurityKeys()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		result.SecurityParameters = x.SecurityParameters.Copy()
+	} else {
+		result.SecurityParameters = sp
 	}
 
 	cursor, err := x.unmarshalHeader(trap, result)
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap: %s\n", err)
-		return err
+		return nil, err
 	}
 
 	if result.Version == Version3 {
@@ -512,20 +510,20 @@ func (x *GoSNMP) UnmarshalTrapBase(trap []byte, result *SnmpPacket, useResponseS
 			err = x.testAuthentication(trap, result, useResponseSecurityParameters)
 			if err != nil {
 				x.Logger.Printf("UnmarshalTrap v3 auth: %s\n", err)
-				return err
+				return nil, err
 			}
 		}
 
 		trap, cursor, err = x.decryptPacket(trap, cursor, result)
 		if err != nil {
 			x.Logger.Printf("UnmarshalTrap v3 decrypt: %s\n", err)
-			return err
+			return nil, err
 		}
 	}
 	err = x.unmarshalPayload(trap, cursor, result)
 	if err != nil {
 		x.Logger.Printf("UnmarshalTrap: %s\n", err)
-		return err
+		return nil, err
 	}
-	return nil
+	return result, nil
 }

--- a/trap_test.go
+++ b/trap_test.go
@@ -153,12 +153,9 @@ SANITY:
 
 		// test enough fields to ensure unmarshalling was successful.
 		// full unmarshal testing is performed in TestUnmarshal
-		if res.Version != test.out.Version {
-			t.Errorf("#%d Version result: %v, test: %v", i, res.Version, test.out.Version)
-		}
-		if res.RequestID != test.out.RequestID {
-			t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
-		}
+		require.Equal(t, test.out.Version, res.Version)
+		require.Equal(t, test.out.RequestID, res.RequestID)
+
 		Default.SecurityParametersTable = nil
 	}
 }

--- a/trap_test.go
+++ b/trap_test.go
@@ -135,7 +135,7 @@ SANITY:
 
 func TestUnmarshalTrapWithMultipleUsers(t *testing.T) {
 	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
-	usmMap := NewSnmpV3SecurityParametersTable()
+	usmMap := NewSnmpV3SecurityParametersTable(NewLogger(log.New(io.Discard, "", 0)))
 	for _, sp := range secParamsList {
 		usmMap.Add(sp.UserName, sp)
 	}

--- a/trap_test.go
+++ b/trap_test.go
@@ -88,7 +88,7 @@ var testsUnmarshalTrap = []struct {
 		},
 	},
 	{
-		snmpv3Trap,
+		snmpV3AuthPrivTrap,
 		&SnmpPacket{
 			Version:   3,
 			PDUType:   SNMPv2Trap,
@@ -135,13 +135,13 @@ SANITY:
 
 func TestUnmarshalTrapWithMultipleUsers(t *testing.T) {
 	Default.Logger = NewLogger(log.New(io.Discard, "", 0))
-	usmMap := NewSnmpV3SecurityParametersMap()
+	usmMap := NewSnmpV3SecurityParametersTable()
 	for _, sp := range secParamsList {
-		usmMap.AddEntry(sp.UserName, sp)
+		usmMap.Add(sp.UserName, sp)
 	}
 SANITY:
 	for i, test := range testsUnmarshalTrap {
-		Default.SecurityParametersMap = usmMap
+		Default.SecurityParametersTable = usmMap
 		Default.Version = Version3
 		var buf = test.in()
 		res, err := Default.UnmarshalTrap(buf, true)
@@ -159,7 +159,7 @@ SANITY:
 		if res.RequestID != test.out.RequestID {
 			t.Errorf("#%d RequestID result: %v, test: %v", i, res.RequestID, test.out.RequestID)
 		}
-		Default.SecurityParametersMap = nil
+		Default.SecurityParametersTable = nil
 	}
 }
 
@@ -189,7 +189,7 @@ func genericV3Trap() []byte {
 /*
 snmptrap -v3 -l authPriv -u myuser2 -a MD5 -A mypassword2 -x AES -X myprivacy2 127.0.0.1:9162 ”  1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 60
 */
-func snmpv3Trap() []byte {
+func snmpV3AuthPrivTrap() []byte {
 	return []byte{
 		0x30, 0x81, 0xbb, 0x02, 0x01, 0x03, 0x30, 0x11, 0x02, 0x04, 0x3a, 0x1c,
 		0xf4, 0xf7, 0x02, 0x03, 0x00, 0xff, 0xe3, 0x04, 0x01, 0x03, 0x02, 0x01,

--- a/trap_test.go
+++ b/trap_test.go
@@ -141,7 +141,7 @@ func TestUnmarshalTrapWithMultipleUsers(t *testing.T) {
 	}
 SANITY:
 	for i, test := range testsUnmarshalTrap {
-		Default.SecurityParametersTable = usmMap
+		Default.TrapSecurityParametersTable = usmMap
 		Default.Version = Version3
 		var buf = test.in()
 		res, err := Default.UnmarshalTrap(buf, true)
@@ -156,7 +156,7 @@ SANITY:
 		require.Equal(t, test.out.Version, res.Version)
 		require.Equal(t, test.out.RequestID, res.RequestID)
 
-		Default.SecurityParametersTable = nil
+		Default.TrapSecurityParametersTable = nil
 	}
 }
 

--- a/v3.go
+++ b/v3.go
@@ -59,6 +59,8 @@ type SnmpV3SecurityParameters interface {
 	encryptPacket(scopedPdu []byte) ([]byte, error)
 	decryptPacket(packet []byte, cursor int) ([]byte, error)
 	getIdentifier() string
+	getLogger() Logger
+	setLogger(log Logger)
 }
 
 func (x *GoSNMP) validateParametersV3() error {

--- a/v3_map.go
+++ b/v3_map.go
@@ -1,0 +1,29 @@
+// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gosnmp
+
+import "fmt"
+
+// SnmpV3SecurityParametersMap is a mapping of usernames to corresponding SNMP V3 Security Model parameters
+type SnmpV3SecurityParametersMap map[string][]SnmpV3SecurityParameters
+
+func NewSnmpV3SecurityParametersMap() SnmpV3SecurityParametersMap {
+	return make(map[string][]SnmpV3SecurityParameters)
+}
+
+func (uspm SnmpV3SecurityParametersMap) AddEntry(key string, sp SnmpV3SecurityParameters) {
+	uspm[key] = append(uspm[key], sp)
+}
+
+func (uspm SnmpV3SecurityParametersMap) getEntry(key string) ([]SnmpV3SecurityParameters, error) {
+	if sp, ok := uspm[key]; ok {
+		return sp, nil
+	}
+	return nil, fmt.Errorf("No security parameters found for the key %s", key)
+}

--- a/v3_map.go
+++ b/v3_map.go
@@ -1,10 +1,6 @@
-// Copyright 2012 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2023 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
-
-// Copyright 2009 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
 
 package gosnmp
 

--- a/v3_map.go
+++ b/v3_map.go
@@ -25,11 +25,14 @@ func NewSnmpV3SecurityParametersTable() *SnmpV3SecurityParametersTable {
 	}
 }
 
-func (spm *SnmpV3SecurityParametersTable) Add(key string, sp SnmpV3SecurityParameters) {
+func (spm *SnmpV3SecurityParametersTable) Add(key string, sp SnmpV3SecurityParameters) error {
 	spm.mu.Lock()
 	defer spm.mu.Unlock()
-
+	if err := sp.InitSecurityKeys(); err != nil {
+		return err
+	}
 	spm.table[key] = append(spm.table[key], sp)
+	return nil
 }
 
 func (spm *SnmpV3SecurityParametersTable) Get(key string) ([]SnmpV3SecurityParameters, error) {

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -158,6 +158,14 @@ func (sp *UsmSecurityParameters) getIdentifier() string {
 	return sp.UserName
 }
 
+func (sp *UsmSecurityParameters) getLogger() Logger {
+	return sp.Logger
+}
+
+func (sp *UsmSecurityParameters) setLogger(log Logger) {
+	sp.Logger = log
+}
+
 // Description logs authentication paramater information to the provided GoSNMP Logger
 func (sp *UsmSecurityParameters) Description() string {
 	var sb strings.Builder

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -154,6 +154,10 @@ type UsmSecurityParameters struct {
 	Logger Logger
 }
 
+func (sp *UsmSecurityParameters) getIdentifier() string {
+	return sp.UserName
+}
+
 // Description logs authentication paramater information to the provided GoSNMP Logger
 func (sp *UsmSecurityParameters) Description() string {
 	var sb strings.Builder


### PR DESCRIPTION
Greetings 😄  PR addressing issue #302 

This PR adds multiple security parameter support for receiving SNMP V3 traps.

### Notes:
* For the USM model, the identifier for the security parameters to unmarshal with will be the username.
* This is supporting that the configuration of multiple security parameters in the conf.yaml may have usernames with the same identifier, so multiple security parameters can be tried until one satisfies the authentication/privacy protocols

### Example steps
1. Run the listener in `trapserver_v3`
2. Send a trap, examples below:
```
$ snmptrap -v3 -l authPriv -u myuser2 -a MD5 -A mypassword2 -x AES -X myprivacy2 127.0.0.1:9162 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456

$ snmptrap -v3 -l authPriv -u myuser2 -a SHA -A mypassword2 -x DES -X myprivacy2 127.0.0.1:9162 '' 1.3.6.1.4.1.8072.2.3.0.1 1.3.6.1.4.1.8072.2.3.2.1 i 123456
```