### PR TITLE
Remove GoSNMP.NonRepeaters.

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -111,10 +111,6 @@ type GoSNMP struct {
 	// See comments in https://github.com/gosnmp/gosnmp/issues/100
 	MaxRepetitions uint32
 
-	// NonRepeaters sets the GETBULK max-repeaters used by BulkWalk*.
-	// (default: 0 as per RFC 1905)
-	NonRepeaters int
-
 	// UseUnconnectedUDPSocket if set, changes net.Conn to be unconnected UDP socket.
 	// Some multi-homed network gear isn't smart enough to send SNMP responses
 	// from the address it received the requests on. To work around that,

--- a/gosnmp_api_test.go
+++ b/gosnmp_api_test.go
@@ -33,7 +33,6 @@ func TestAPIConfigTypes(t *testing.T) {
 	g.Retries = 0
 	g.MaxOids = 0
 	g.MaxRepetitions = 0
-	g.NonRepeaters = 0
 	g.Logger = gosnmp.NewLogger(log.New(io.Discard, "", 0))
 	var c net.Conn
 	c = g.Conn

--- a/interface.go
+++ b/interface.go
@@ -147,12 +147,6 @@ type Handler interface {
 	// SetMaxRepetitions sets the maxRepetitions
 	SetMaxRepetitions(maxRepetitions uint32)
 
-	// NonRepeaters gets the nonRepeaters
-	NonRepeaters() int
-
-	// SetNonRepeaters sets the nonRepeaters
-	SetNonRepeaters(nonRepeaters int)
-
 	// MsgFlags gets the MsgFlags
 	MsgFlags() SnmpV3MsgFlags
 
@@ -283,14 +277,6 @@ func (x *snmpHandler) MaxRepetitions() uint32 {
 // SetMaxRepetitions wraps to 0 at max int32.
 func (x *snmpHandler) SetMaxRepetitions(maxRepetitions uint32) {
 	x.GoSNMP.MaxRepetitions = (maxRepetitions & 0x7FFFFFFF)
-}
-
-func (x *snmpHandler) NonRepeaters() int {
-	return x.GoSNMP.NonRepeaters
-}
-
-func (x *snmpHandler) SetNonRepeaters(nonRepeaters int) {
-	x.GoSNMP.NonRepeaters = nonRepeaters
 }
 
 func (x *snmpHandler) MsgFlags() SnmpV3MsgFlags {

--- a/walk.go
+++ b/walk.go
@@ -44,7 +44,7 @@ RequestLoop:
 
 		switch getRequestType {
 		case GetBulkRequest:
-			response, err = x.GetBulk([]string{oid}, uint8(x.NonRepeaters), maxReps)
+			response, err = x.GetBulk([]string{oid}, 0, maxReps)
 		case GetNextRequest:
 			response, err = x.GetNext([]string{oid})
 		case GetRequest:


### PR DESCRIPTION
There's a value `.NonRepeaters` defined in [gosnmp.go](https://github.com/gosnmp/gosnmp/blob/0dd8e40cc4fc54b97ea749511edde593311df1de/gosnmp.go#L116). The comment on this value is wrong - there is no `max-repeaters` value defined by that RFC, only `max-repetitions`, which is set by `.MaxRepetitions`. In fact, what this attribute is setting is the `non-repeaters` attribute, which is NOT something that makes sense as a global setting - it indicates how many of the oids provided in a `GETBULK` request should only have one value fetched, instead of bulk-fetching `max-repetitions` OIDs starting at that point.

In the only place this attribute is used, as part of [walk.go](https://github.com/gosnmp/gosnmp/blob/master/walk.go#L47), there is exactly one OID being passed in, and the whole point of using `GetBulk` is that we want to fetch more than one value, so in this call `non-repeaters` should always be set to 0; it should not be configurable. Setting it to anything greater than zero simply means that `GetBulk` will now only fetch one value for that OID; if you want that behavior, you should be using `.Walk` instead of `.BulkWalk`.

So as a parameter, its sole behavior is to make `.BulkWalk*` behave unexpectedly badly; it is not something that should exist.