### PR TITLE
Update build and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.21
+    - image: cimg/go:1.24
 
 jobs:
   generate:
@@ -20,7 +20,6 @@ jobs:
     executor: golang
     steps:
     - checkout
-    - run: make tools
     - run: make lint
 
   fuzz:
@@ -80,5 +79,6 @@ workflows:
             - "amd64"
             - "386"
             goversion:
-            - "1.20"
-            - "1.21"
+            - "1.22"
+            - "1.23"
+            - "1.24"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -37,7 +37,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -51,4 +51,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,34 @@
+---
+name: golangci-lint
+on:
+  push:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+  pull_request:
+
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
+jobs:
+  golangci:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: 1.24.x
+      - name: Lint
+        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+        with:
+          args: --verbose
+          version: v1.64.5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,9 @@ run:
 linters:
   enable:
   - bodyclose
+  - copyloopvar
   - dogsled
   - dupl
-  - exportloopref # Replaces scopelint
   - gochecknoglobals
   - goconst
   - gocritic
@@ -29,15 +29,6 @@ linters:
   # - lll
   # - nestif
   # - prealloc
-  disable:
-  # Disable soon to deprecated[1] linters that lead to false
-  # positives when build tags disable certain files[2]
-  # 1: https://github.com/golangci/golangci-lint/issues/1841
-  # 2: https://github.com/prometheus/node_exporter/issues/1545
-  - deadcode
-  - unused
-  - structcheck
-  - varcheck
 
 linters-settings:
   gofmt:
@@ -45,11 +36,12 @@ linters-settings:
   gocyclo:
     min-complexity: 20
   govet:
-    check-shadowing: true
+    enable:
+    - shadow
 
 issues:
   exclude-rules:
-    - path: _test.go
-      linters:
-        - gochecknoglobals
-        - nolintlint
+  - path: _test.go
+    linters:
+    - gochecknoglobals
+    - nolintlint

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
-.PHONY: test lint lint-all lint-examples tools
-
-GOLANGCI_LINT_VERSION ?= v1.54.2
-
+.PHONY: test
 test:
 	go test *.go
 
+.PHONY: lint
 lint: check_license
-	golangci-lint run -v
-
-tools:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
-		| sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 .PHONY: check_license
 check_license:
@@ -22,4 +15,3 @@ check_license:
                echo "license header checking failed:"; echo "$${licRes}"; \
                exit 1; \
        fi
-

--- a/generic_e2e_test.go
+++ b/generic_e2e_test.go
@@ -23,6 +23,15 @@ import (
 	"time"
 )
 
+func isUsingSnmpLabs() bool {
+	return useSnmpLabsCredentials
+}
+
+// conveniently enable demo.snmplabs.com for a one test
+func useSnmpLabs(use bool) {
+	useSnmpLabsCredentials = use
+}
+
 func getTarget(t *testing.T) (string, uint16) {
 	var envTarget string
 	var envPort string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gosnmp/gosnmp
 
-go 1.20
+go 1.22.0
 
 require (
 	github.com/golang/mock v1.6.0

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -309,7 +309,7 @@ func (x *GoSNMP) connect(networkSuffix string) error {
 		if err != nil {
 			return fmt.Errorf("error occurred while generating random: %w", err)
 		}
-		x.random = uint32(n.Uint64())
+		x.random = uint32(n.Uint64()) //nolint:gosec
 	}
 	// http://tools.ietf.org/html/rfc3412#section-6 - msgID only uses the first 31 bits
 	// msgID INTEGER (0..2147483647)
@@ -672,7 +672,7 @@ func ToBigInt(value interface{}) *big.Int {
 	case int64:
 		val = value
 	case uint:
-		val = int64(value)
+		val = int64(value) //nolint:gosec
 	case uint8:
 		val = int64(value)
 	case uint16:

--- a/helper.go
+++ b/helper.go
@@ -91,7 +91,7 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 		retVal.Type = Asn1BER(data[0])
 		switch Asn1BER(data[0]) {
 		case Uinteger32:
-			retVal.Value = uint32(ret)
+			retVal.Value = uint32(ret) //nolint:gosec
 		default:
 			retVal.Value = ret
 		}
@@ -273,7 +273,7 @@ func marshalBase128Int(out io.ByteWriter, n int64) (err error) {
 	}
 
 	for i := l - 1; i >= 0; i-- {
-		o := byte(n >> uint(i*7))
+		o := byte(n >> uint(i*7)) //nolint:gosec
 		o &= 0x7f
 		if i != 0 {
 			o |= 0x80
@@ -307,7 +307,7 @@ func marshalInt32(value int) ([]byte, error) {
 	const mask1 uint32 = 0xFFFFFF80
 	const mask2 uint32 = 0xFFFF8000
 	const mask3 uint32 = 0xFF800000
-	const mask4 uint32 = 0x80000000
+	// const mask4 uint32 = 0x80000000
 	// ITU-T Rec. X.690 (2002) 8.3.2
 	// If the contents octets of an integer value encoding consist of more than
 	// one octet, then the bits of the first octet and bit 8 of the second octet:
@@ -315,7 +315,7 @@ func marshalInt32(value int) ([]byte, error) {
 	//  b) shall not all be zero
 	// These rules ensure that an integer value is always encoded in the smallest
 	// possible number of octets.
-	val := uint32(value)
+	val := uint32(value) //nolint:gosec
 	switch {
 	case val&mask1 == 0 || val&mask1 == mask1:
 		return []byte{byte(val)}, nil
@@ -343,7 +343,7 @@ func marshalUint32(v interface{}) ([]byte, error) {
 	case uint32:
 		source = val
 	case uint:
-		source = uint32(val)
+		source = uint32(val) //nolint:gosec
 	case uint8:
 		source = uint32(val)
 	case SNMPError:
@@ -578,8 +578,8 @@ func parseInt64(bytes []byte) (int64, error) {
 		ret |= int64(bytes[bytesRead])
 	}
 	// Shift up and down in order to sign extend the result.
-	ret <<= 64 - uint8(len(bytes))*8
-	ret >>= 64 - uint8(len(bytes))*8
+	ret <<= 64 - uint8(len(bytes))*8 //nolint:gosec
+	ret >>= 64 - uint8(len(bytes))*8 //nolint:gosec
 	return ret, nil
 }
 
@@ -781,7 +781,7 @@ func parseUint32(bytes []byte) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint32(ret), nil
+	return uint32(ret), nil //nolint:gosec
 }
 
 // parseUint treats the given bytes as a big-endian, signed integer and returns
@@ -838,14 +838,14 @@ func (b BitStringValue) At(i int) int {
 		return 0
 	}
 	x := i / 8
-	y := 7 - uint(i%8)
+	y := 7 - uint(i%8) //nolint:gosec
 	return int(b.Bytes[x]>>y) & 1
 }
 
 // RightAlign returns a slice where the padding bits are at the beginning. The
 // slice may share memory with the BitString.
 func (b BitStringValue) RightAlign() []byte {
-	shift := uint(8 - (b.BitLength % 8))
+	shift := uint(8 - (b.BitLength % 8)) //nolint:gosec
 	if shift == 8 || len(b.Bytes) == 0 {
 		return b.Bytes
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -522,7 +522,7 @@ func (packet *SnmpPacket) marshalMsg() ([]byte, error) {
 		}
 	} else {
 		// community
-		buf.Write([]byte{4, uint8(len(packet.Community))})
+		buf.Write([]byte{4, uint8(len(packet.Community))}) //nolint:gosec
 		buf.WriteString(packet.Community)
 		// pdu
 		pdu, err2 := packet.marshalPDU()
@@ -704,7 +704,8 @@ func (packet *SnmpPacket) marshalPDU() ([]byte, error) {
 func (packet *SnmpPacket) marshalVBL() ([]byte, error) {
 	vblBuf := new(bytes.Buffer)
 	for _, pdu := range packet.Variables {
-		pdu := pdu
+		// The copy of the 'for' variable "pdu" can be deleted (Go 1.22+)
+		pdu := pdu //nolint:copyloopvar
 		vb, err := marshalVarbind(&pdu)
 		if err != nil {
 			return nil, err
@@ -1019,7 +1020,7 @@ func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket)
 
 	if version, ok := rawVersion.(int); ok {
 		x.Logger.Printf("Parsed version %d", version)
-		return SnmpVersion(version), cursor, nil
+		return SnmpVersion(version), cursor, nil //nolint:gosec
 	}
 	return 0, cursor, err
 }
@@ -1115,7 +1116,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 	}
 
 	if requestid, ok := rawRequestID.(int); ok {
-		response.RequestID = uint32(requestid)
+		response.RequestID = uint32(requestid) //nolint:gosec
 		x.Logger.Printf("requestID: %d", response.RequestID)
 	}
 
@@ -1131,7 +1132,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if nonRepeaters, ok := rawNonRepeaters.(int); ok {
-			response.NonRepeaters = uint8(nonRepeaters)
+			response.NonRepeaters = uint8(nonRepeaters) //nolint:gosec
 		}
 
 		// Parse Max Repetitions
@@ -1145,7 +1146,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if maxRepetitions, ok := rawMaxRepetitions.(int); ok {
-			response.MaxRepetitions = uint32(maxRepetitions & 0x7FFFFFFF)
+			response.MaxRepetitions = uint32(maxRepetitions & 0x7FFFFFFF) //nolint:gosec
 		}
 	} else {
 		// Parse Error-Status
@@ -1159,8 +1160,8 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if errorStatus, ok := rawError.(int); ok {
-			response.Error = SNMPError(errorStatus)
-			x.Logger.Printf("errorStatus: %d", uint8(errorStatus))
+			response.Error = SNMPError(errorStatus)                //nolint:gosec
+			x.Logger.Printf("errorStatus: %d", uint8(errorStatus)) //nolint:gosec
 		}
 
 		// Parse Error-Index
@@ -1174,8 +1175,8 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if errorindex, ok := rawErrorIndex.(int); ok {
-			response.ErrorIndex = uint8(errorindex)
-			x.Logger.Printf("error-index: %d", uint8(errorindex))
+			response.ErrorIndex = uint8(errorindex)               //nolint:gosec
+			x.Logger.Printf("error-index: %d", uint8(errorindex)) //nolint:gosec
 		}
 	}
 

--- a/trap.go
+++ b/trap.go
@@ -65,7 +65,7 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 		}
 
 		if trap.Variables[0].Type != TimeTicks {
-			now := uint32(time.Now().Unix())
+			now := uint32(time.Now().Unix()) //nolint:gosec
 			timetickPDU := SnmpPDU{Name: "1.3.6.1.2.1.1.3.0", Type: TimeTicks, Value: now}
 			// prepend timetickPDU
 			trap.Variables = append([]SnmpPDU{timetickPDU}, trap.Variables...)

--- a/v3.go
+++ b/v3.go
@@ -367,7 +367,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if MsgID, ok := rawMsgID.(int); ok {
-		response.MsgID = uint32(MsgID)
+		response.MsgID = uint32(MsgID) //nolint:gosec
 		x.Logger.Printf("Parsed message ID %d", MsgID)
 	}
 
@@ -381,7 +381,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if MsgMaxSize, ok := rawMsgMaxSize.(int); ok {
-		response.MsgMaxSize = uint32(MsgMaxSize)
+		response.MsgMaxSize = uint32(MsgMaxSize) //nolint:gosec
 		x.Logger.Printf("Parsed message max size %d", MsgMaxSize)
 	}
 
@@ -409,7 +409,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if SecModel, ok := rawSecModel.(int); ok {
-		response.SecurityModel = SnmpV3SecurityModel(SecModel)
+		response.SecurityModel = SnmpV3SecurityModel(SecModel) //nolint:gosec
 		x.Logger.Printf("Parsed security model %d", SecModel)
 	}
 

--- a/v3_credentials_test.go
+++ b/v3_credentials_test.go
@@ -121,20 +121,7 @@ var useSnmpLabsCredentials = false
 
 // TODO get above credentials into snmpsimd, so *all* tests can be run. Combine with settings in `snmp_users.sh`
 
-const cIdxUserName = 0
-const cIdxAuthKey = 1
-const cIdxPrivKey = 2
-
-func isUsingSnmpLabs() bool {
-	return useSnmpLabsCredentials
-}
-
-// conveniently enable demo.snmplabs.com for a one test
-func useSnmpLabs(use bool) {
-	useSnmpLabsCredentials = use
-}
-
-//nolint:misspell
+//nolint:unused,misspell
 func getCredentials(t *testing.T, authProtocol SnmpV3AuthProtocol, privProtocol SnmpV3PrivProtocol) []string {
 	var credentials []string
 	if useSnmpLabsCredentials {
@@ -150,16 +137,20 @@ func getCredentials(t *testing.T, authProtocol SnmpV3AuthProtocol, privProtocol 
 	return credentials
 }
 
+//nolint:unused
 func getUserName(t *testing.T, authProtocol SnmpV3AuthProtocol, privProtocol SnmpV3PrivProtocol) string {
+	const cIdxUserName = 0
 	return getCredentials(t, authProtocol, privProtocol)[cIdxUserName]
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func getAuthKey(t *testing.T, authProtocol SnmpV3AuthProtocol, privProtocol SnmpV3PrivProtocol) string {
+	const cIdxAuthKey = 1
 	return getCredentials(t, authProtocol, privProtocol)[cIdxAuthKey]
 }
 
-//nolint:unused,deadcode
+//nolint:unused
 func getPrivKey(t *testing.T, authProtocol SnmpV3AuthProtocol, privProtocol SnmpV3PrivProtocol) string {
+	const cIdxPrivKey = 2
 	return getCredentials(t, authProtocol, privProtocol)[cIdxPrivKey]
 }

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -1006,7 +1006,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	}
 	cursor += count
 	if AuthoritativeEngineBoots, ok := rawMsgAuthoritativeEngineBoots.(int); ok {
-		sp.AuthoritativeEngineBoots = uint32(AuthoritativeEngineBoots)
+		sp.AuthoritativeEngineBoots = uint32(AuthoritativeEngineBoots) //nolint:gosec
 		sp.Logger.Printf("Parsed authoritativeEngineBoots %d", AuthoritativeEngineBoots)
 	}
 
@@ -1016,7 +1016,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	}
 	cursor += count
 	if AuthoritativeEngineTime, ok := rawMsgAuthoritativeEngineTime.(int); ok {
-		sp.AuthoritativeEngineTime = uint32(AuthoritativeEngineTime)
+		sp.AuthoritativeEngineTime = uint32(AuthoritativeEngineTime) //nolint:gosec
 		sp.Logger.Printf("Parsed authoritativeEngineTime %d", AuthoritativeEngineTime)
 	}
 

--- a/walk.go
+++ b/walk.go
@@ -44,7 +44,7 @@ RequestLoop:
 
 		switch getRequestType {
 		case GetBulkRequest:
-			response, err = x.GetBulk([]string{oid}, uint8(x.NonRepeaters), maxReps)
+			response, err = x.GetBulk([]string{oid}, uint8(x.NonRepeaters), maxReps) //nolint:gosec
 		case GetNextRequest:
 			response, err = x.GetNext([]string{oid})
 		case GetRequest:


### PR DESCRIPTION
* Migrate golangci-lint to GitHub actions.
* Update minimum Go version to 1.22.0.
* Update Go test matrix to test latest Go versions.
* Enable dependabot for GitHub actions.
* Update and pin GitHub actions to SHA for supply chain security.
* golangci-lint: Replace exportloopref with copyloopvar.
* golangci-lint: Remove deprecated disabled linters.
* Fixup various golangci-lint issues.
* Mark a number of `gosec` linting issues with nolint. These are all int/uint overflow warnings. These may be intentional, but we need to review them.