### PR TITLE
`baseOid` fixes

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -29,7 +29,7 @@ const (
 	MaxOids = 60
 
 	// Base OID for MIB-2 defined SNMP variables
-	baseOid = ".1.3.6.1.2.1"
+	baseOid = ".1"
 
 	// Max oid sub-identifier value
 	// https://tools.ietf.org/html/rfc2578#section-7.1.3

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -28,9 +28,6 @@ const (
 	// to change this in the GoSNMP struct
 	MaxOids = 60
 
-	// Base OID for MIB-2 defined SNMP variables
-	baseOid = ".1"
-
 	// Max oid sub-identifier value
 	// https://tools.ietf.org/html/rfc2578#section-7.1.3
 	MaxObjectSubIdentifierValue = 4294967295
@@ -100,6 +97,9 @@ type GoSNMP struct {
 
 	// OnFinish is called when the request completed.
 	OnFinish func(*GoSNMP)
+
+	// Base OID for MIB-2 defined SNMP variables
+	BaseOid string
 
 	// MaxOids is the maximum number of oids allowed in a Get().
 	// (default: MaxOids)
@@ -174,6 +174,7 @@ type GoSNMP struct {
 }
 
 // Default connection settings
+// BaseOid is .1.3.6.1.2.1. When walking a MIB, results may be limited.
 //
 //nolint:gochecknoglobals
 var Default = &GoSNMP{
@@ -183,6 +184,7 @@ var Default = &GoSNMP{
 	Version:            Version2c,
 	Timeout:            time.Duration(2) * time.Second,
 	Retries:            3,
+	BaseOid:            ".1.3.6.1.2.1",
 	ExponentialTimeout: true,
 	MaxOids:            MaxOids,
 }

--- a/helper.go
+++ b/helper.go
@@ -469,7 +469,7 @@ func marshalObjectIdentifier(oid string) ([]byte, error) {
 		}
 		i++
 	}
-	if i < 2 || i > 128 {
+	if i < 1 || i > 128 {
 		return []byte{}, fmt.Errorf("unable to marshal OID: Invalid object identifier")
 	}
 

--- a/walk.go
+++ b/walk.go
@@ -11,7 +11,7 @@ import (
 
 func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) error {
 	if rootOid == "" || rootOid == "." {
-		rootOid = baseOid
+		rootOid = x.BaseOid
 	}
 
 	if !strings.HasPrefix(rootOid, ".") {


### PR DESCRIPTION
- `baseOid` moved to `GoSNMP`
- Added a warning that using `gosnmp.Default`, users may not get the MIB values completely (#486).

Example of using the updated `GoSNMP` structure:
```sh
func main() {
	var (
		err error
		pdu []gosnmp.SnmpPDU
	)
	gosnmp.Default.Target = "39.61.33.251"
	gosnmp.Default.Port = 161
	gosnmp.Default.BaseOid = ".1" // I want all the varbinds, including 1.3.6.1.4.1.50001
	err = gosnmp.Default.Connect()
	if err != nil {
		log.Fatal(err.Error())
		return
	}
	defer func() {
		err = gosnmp.Default.Conn.Close()
		if err != nil {
			log.Fatal(err.Error())
		}
	}()
	pdu, err = gosnmp.Default.BulkWalkAll(".")
	if err != nil {
		log.Fatal(err.Error())
		return
	}
	for _, unit := range pdu {
		fmt.Println(unit.Name, "=", unit.Type, ":", unit.Value)
	}
	return
}
```