### PR TITLE
fix: Verify authentication independent of packet msg flags

### DIFF
--- a/trap_test.go
+++ b/trap_test.go
@@ -1457,6 +1457,7 @@ func TestSendV3TrapAuthNoPrivFailsWithNoAuthNoPriv(t *testing.T) {
 	}
 }
 
+/*
 func TestSendV3EngineIdDiscovery(t *testing.T) {
 	tl := NewTrapListener()
 	defer tl.Close()
@@ -1530,3 +1531,4 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 	require.Equal(t, result.SecurityParameters.(*UsmSecurityParameters).AuthoritativeEngineID, authorativeEngineID, "invalid authoritativeEngineID")
 	require.Equal(t, result.PDUType, Report, "invalid received PDUType")
 }
+*/

--- a/trap_test.go
+++ b/trap_test.go
@@ -1457,7 +1457,6 @@ func TestSendV3TrapAuthNoPrivFailsWithNoAuthNoPriv(t *testing.T) {
 	}
 }
 
-/*
 func TestSendV3EngineIdDiscovery(t *testing.T) {
 	tl := NewTrapListener()
 	defer tl.Close()
@@ -1475,10 +1474,9 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 	}
 	tl.Params = Default
 	tl.Params.Version = Version3
-	tl.Params.SecurityParameters = sp.Copy()
+	tl.Params.SecurityParameters = sp
 	tl.Params.SecurityModel = UserSecurityModel
 	tl.Params.MsgFlags = AuthPriv
-	tl.Params.Logger = NewLogger(&testLogger{prefix: "[server] ", t: t})
 
 	// listener goroutine
 	errch := make(chan error)
@@ -1496,6 +1494,8 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 		t.Fatalf("error in listen: %v", err)
 	}
 
+	clientParams := sp.Copy()
+	clientParams.(*UsmSecurityParameters).AuthoritativeEngineID = ""
 	ts := &GoSNMP{
 		Target:             trapTestAddress,
 		Port:               trapTestPort,
@@ -1504,25 +1504,22 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 		Retries:            3,
 		MaxOids:            MaxOids,
 		SecurityModel:      UserSecurityModel,
-		SecurityParameters: sp.Copy(),
+		SecurityParameters: clientParams,
 		MsgFlags:           AuthPriv,
-		Logger:             NewLogger(&testLogger{prefix: "[client] ", t: t}),
 	}
 	require.NoError(t, ts.Connect())
 	defer ts.Conn.Close()
 
-	packetParams := &UsmSecurityParameters{Logger: NewLogger(&testLogger{t: t})}
 	getEngineIDRequest := SnmpPacket{
 		Version:            Version3,
-		MsgFlags:           Reportable | NoAuthNoPriv,
+		MsgFlags:           Reportable,
 		SecurityModel:      UserSecurityModel,
-		SecurityParameters: packetParams,
+		SecurityParameters: &UsmSecurityParameters{},
 		ContextEngineID:    unknownEngineID,
 		PDUType:            GetRequest,
 		MsgID:              1824792385,
 		RequestID:          1411852680,
 		MsgMaxSize:         65507,
-		Logger:             NewLogger(&testLogger{prefix: "[packet] ", t: t}),
 	}
 	result, err := ts.sendOneRequest(&getEngineIDRequest, true)
 	require.NoError(t, err, "sendOneRequest failed")
@@ -1530,4 +1527,3 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 	require.Equal(t, result.SecurityParameters.(*UsmSecurityParameters).AuthoritativeEngineID, authorativeEngineID, "invalid authoritativeEngineID")
 	require.Equal(t, result.PDUType, Report, "invalid received PDUType")
 }
-*/

--- a/trap_test.go
+++ b/trap_test.go
@@ -1508,7 +1508,6 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 		MsgFlags:           AuthPriv,
 		Logger:             NewLogger(&testLogger{prefix: "[client] ", t: t}),
 	}
-
 	require.NoError(t, ts.Connect())
 	defer ts.Conn.Close()
 
@@ -1525,9 +1524,9 @@ func TestSendV3EngineIdDiscovery(t *testing.T) {
 		MsgMaxSize:         65507,
 		Logger:             NewLogger(&testLogger{prefix: "[packet] ", t: t}),
 	}
-	_ = unknownEngineID
 	result, err := ts.sendOneRequest(&getEngineIDRequest, true)
 	require.NoError(t, err, "sendOneRequest failed")
+
 	require.Equal(t, result.SecurityParameters.(*UsmSecurityParameters).AuthoritativeEngineID, authorativeEngineID, "invalid authoritativeEngineID")
 	require.Equal(t, result.PDUType, Report, "invalid received PDUType")
 }

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -794,6 +794,12 @@ func (sp *UsmSecurityParameters) isAuthentic(packetBytes []byte, packet *SnmpPac
 	if packetSecParams, err = castUsmSecParams(packet.SecurityParameters); err != nil {
 		return false, err
 	}
+
+	// Verify the username
+	if packetSecParams.UserName != sp.UserName {
+		return false, nil
+	}
+
 	// TODO: investigate call chain to determine if this is really the best spot for this
 	if msgDigest, err = calcPacketDigest(packetBytes, packetSecParams); err != nil {
 		return false, err

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"     //nolint:gosec
 	_ "crypto/sha256" // Register hash function #4 (SHA224), #5 (SHA256)
 	_ "crypto/sha512" // Register hash function #6 (SHA384), #7 (SHA512)
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -66,38 +67,38 @@ func (authProtocol SnmpV3AuthProtocol) HashType() crypto.Hash {
 
 //nolint:gochecknoglobals
 var macVarbinds = [][]byte{
-	{},
-	{byte(OctetString), 0},
-	{byte(OctetString), 12,
+	{},                     // dummy
+	{byte(OctetString), 0}, // NoAuth
+	{byte(OctetString), 12, // MD5
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0},
-	{byte(OctetString), 12,
+	{byte(OctetString), 12, // SHA
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0},
-	{byte(OctetString), 16,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0},
-	{byte(OctetString), 24,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
+	{byte(OctetString), 16, // SHA224
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0},
-	{byte(OctetString), 32,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
+	{byte(OctetString), 24, // SHA256
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0},
-	{byte(OctetString), 48,
+	{byte(OctetString), 32, // SHA384
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0},
+	{byte(OctetString), 48, // SHA512
 		0, 0, 0, 0,
 		0, 0, 0, 0,
 		0, 0, 0, 0,
@@ -696,8 +697,13 @@ func calcPacketDigest(packetBytes []byte, secParams *UsmSecurityParameters) ([]b
 			packetBytes,
 			secParams.SecretKey)
 	}
+	if err != nil {
+		return nil, err
+	}
 
-	return digest, err
+	digest = digest[:len(macVarbinds[secParams.AuthenticationProtocol])-2]
+
+	return digest, nil
 }
 
 // digestRFC7860 calculate digest for incoming messages using HMAC-SHA2 protcols
@@ -793,12 +799,9 @@ func (sp *UsmSecurityParameters) isAuthentic(packetBytes []byte, packet *SnmpPac
 		return false, err
 	}
 
-	for k, v := range []byte(packetSecParams.AuthenticationParameters) {
-		if msgDigest[k] != v {
-			return false, nil
-		}
-	}
-	return true, nil
+	// Check the message signature against the computed digest
+	signature := []byte(packetSecParams.AuthenticationParameters)
+	return subtle.ConstantTimeCompare(msgDigest, signature) == 1, nil
 }
 
 func (sp *UsmSecurityParameters) encryptPacket(scopedPdu []byte) ([]byte, error) {

--- a/v3_usm_test.go
+++ b/v3_usm_test.go
@@ -88,7 +88,7 @@ func TestAuthenticationSHA224(t *testing.T) {
 	require.Equal(t, packetSHA224Authenticated(t), srcPacket, "Wrong message authentication parameters.")
 }
 
-func TestIsAuthenticaSHA224(t *testing.T) {
+func TestIsAuthenticSHA224(t *testing.T) {
 	var err error
 
 	sp := UsmSecurityParameters{
@@ -190,7 +190,7 @@ func TestAuthenticationSHA512(t *testing.T) {
 	require.Equal(t, packetSHA512Authenticated(t), srcPacket, "Wrong message authentication parameters.")
 }
 
-func TestIsAuthenticaSHA512(t *testing.T) {
+func TestIsAuthenticSHA512(t *testing.T) {
 	var err error
 
 	sp := UsmSecurityParameters{


### PR DESCRIPTION
In the current state, a `TrapListener` configured with authentication (e.g. `AuthNoPriv`) will accept all incoming packets sent without authentication enabled e.g. via
```
snmptrap -v 3 -l noAuthNoPriv -u my_user localhost:12399 1 coldStart.0   
```

This is due to the fact that the `isAuthentic` function will _only_ iterate over the authentication parameters sent by the client, which is empty for `NoAuthNoPriv`, and therefore completely ignores the authentication settings for the `TrapListener` and potentially for other uses of the USM implementation. Furthermore, the username is not validated in case we do not use a `TrapSecurityParametersTable`.

The current behavior therefore is a security issue as a client can simply bypass security of the server by sending unauthenticated messages!

This PR ensures that we _always_ respect the server security settings by fully matching the message signature against the expected digest. The PR here uses cryptographically safe functions with constant time to avoid side-channel attacks. 
Additionally, the  username is _always_ validated.

Last but not least, exclude discovery messages from authentication handling as they MUST be unauthenticated. Handle this special case.