### PR TITLE
Added (t *TrapListener) WithBufferSize(i uint) *TrapListener

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -169,12 +169,12 @@ func NewTrapListener() *TrapListener {
 
 // WithBufferSize changes the snmp message buffer size of the current TrapListener
 //
-// NOTE: The buffer size cannot be less than 484 bytes, the default size is 4096 bytes
+// NOTE: The buffer size cannot be 0 bytes, the default size is 4096 bytes
 func (t *TrapListener) WithBufferSize(i uint) *TrapListener {
-	if i < 484 {
-		t.buffSize = 484 // RFC 1157
-		return t
+	if i < 1 {
+		i = 1
 	}
+
 	t.buffSize = i
 	return t
 }

--- a/trap.go
+++ b/trap.go
@@ -256,7 +256,7 @@ func (t *TrapListener) listenUDP(addr string) error {
 
 		default:
 			buf := make([]byte, t.buffSize)
-			rlen, remote, err := t.conn.ReadFromUDP(buf[:])
+			rlen, remote, err := t.conn.ReadFromUDP(buf)
 			if err != nil {
 				if atomic.LoadInt32(&t.finish) == 1 {
 					// err most likely comes from reading from a closed connection

--- a/v3.go
+++ b/v3.go
@@ -112,7 +112,7 @@ func (x *GoSNMP) testAuthentication(packet []byte, result *SnmpPacket, useRespon
 	msgSecParams := result.SecurityParameters.(*UsmSecurityParameters)
 	if msgFlags&NoAuthNoPriv == 0 && // NoAuthNoPriv method
 		msgSecParams.UserName == "" && // empty username
-		msgSecParams.AuthoritativeEngineID == "" && // empty authorative engine ID
+		msgSecParams.AuthoritativeEngineID == "" && // empty authoritative engine ID
 		len(result.Variables) == 0 { // empty variable binding list
 		return nil
 	}


### PR DESCRIPTION
Hello,

Would you like to review my changes and add a variable size snmp trap message buffer to your code, since in practice it turned out that many snmp trap and inform messages exceed the size of 4 KB.