### PR TITLE
Dockerfile: bump to go 1.22 and unbreak workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine
+FROM golang:1.22-alpine
 
 # Install deps
 RUN apk add --no-cache  \
@@ -23,16 +23,13 @@ RUN addgroup -g 1001                \
             -G gosnmp gosnmp
 
 RUN chmod -R a+rw /etc/snmp /var/lib/net-snmp/
-RUN pip install snmpsim
 
 # Copy local branch into container
 USER gosnmp
 WORKDIR /go/src/github.com/gosnmp/gosnmp
 COPY --chown=gosnmp . .
 
-RUN go get github.com/stretchr/testify/assert && \
-    make tools && \
-    make lint
+RUN make lint
 
 ENV GOSNMP_TARGET=127.0.0.1
 ENV GOSNMP_PORT=1024

--- a/build_tests.sh
+++ b/build_tests.sh
@@ -1,17 +1,12 @@
 #!/usr/bin/env bash
 
-if [ "${GOSNMP_SNMPD}" != "" ]; then
-    echo "Using $(snmpd --version | awk /version:/)"
-    ./snmp_users.sh
-    sed -i -e 's/^agentAddress.*/agentAddress udp:127.0.0.1:1024/' /etc/snmp/snmpd.conf
-    sed -i -e 's/ localhost / 127.0.0.1 /' /etc/snmp/snmpd.conf
-    sed -i -e 's/.*trapsink.*//' /etc/snmp/snmpd.conf
-    sed -i -e 's/.*master\s*agentx//' /etc/snmp/snmpd.conf
-    snmpd
-else
-    echo "Using snmpsimd simulator"
-    snmpsimd.py --logging-method=null --agent-udpv4-endpoint=127.0.0.1:1024 &
-fi
+echo "Using $(snmpd --version | awk /version:/)"
+./snmp_users.sh
+sed -i -e 's/^agentAddress.*/agentAddress udp:127.0.0.1:1024/' /etc/snmp/snmpd.conf
+sed -i -e 's/ localhost / 127.0.0.1 /' /etc/snmp/snmpd.conf
+sed -i -e 's/.*trapsink.*//' /etc/snmp/snmpd.conf
+sed -i -e 's/.*master\s*agentx//' /etc/snmp/snmpd.conf
+snmpd
 
 go test -v -tags helper
 go test -v -tags marshal


### PR DESCRIPTION
This will allow one to again develop and test locally against the project before submitting a PR.

## Dockerfile:
* Bump go to 1.22 as per go.mod
* Remove broken pip snmpsim test flow
* Remove removed Makefile target
* Fix testify assert dep

## generic_e2e_test.go:
* In TestGenericFailureUnknownHost support both Podman and Docker