### PR TITLE
Fix: Set the Reportable flag in trap.IsInform messages

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -62,8 +62,12 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 		// If it's an inform, do that instead.
 		if trap.IsInform {
 			pdutype = InformRequest
-			//incase of inform we would need the response so setting this
-			//explictly for inform request
+			// Per RFC 3414 Section 4:
+			// When sending an SNMPv3 InformRequest, the Reportable flag MUST be set in MsgFlags.
+			// This ensures that the authoritative engine will return a Report PDU containing
+			// engineBoots and engineTime for time synchronization which is required before
+			// authenticated communication can succeed. Without this, the engine may reject
+			// the Inform as out-of-time-window or unknown engine.
 			x.MsgFlags = (x.MsgFlags | Reportable)
 		}
 

--- a/trap.go
+++ b/trap.go
@@ -62,6 +62,9 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 		// If it's an inform, do that instead.
 		if trap.IsInform {
 			pdutype = InformRequest
+			//incase of inform we would need the response so setting this
+			//explictly for inform request
+			x.MsgFlags = (x.MsgFlags | Reportable)
 		}
 
 		if trap.Variables[0].Type != TimeTicks {


### PR DESCRIPTION
Per RFC 3414 Section 4:

When sending an SNMPv3 InformRequest, the Reportable flag MUST be set in MsgFlags.
This ensures that the authoritative engine will return a Report PDU containing
engineBoots and engineTime for time synchronization which is required before
authenticated communication can succeed. Without this, the engine may reject
the Inform as out-of-time-window or unknown engine.