### PR TITLE
Deprecate NonRepeaters

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -111,8 +111,7 @@ type GoSNMP struct {
 	// See comments in https://github.com/gosnmp/gosnmp/issues/100
 	MaxRepetitions uint32
 
-	// NonRepeaters sets the GETBULK max-repeaters used by BulkWalk*.
-	// (default: 0 as per RFC 1905)
+	// Deprecated: This parameter is not used and ignored
 	NonRepeaters int
 
 	// UseUnconnectedUDPSocket if set, changes net.Conn to be unconnected UDP socket.

--- a/interface.go
+++ b/interface.go
@@ -147,12 +147,6 @@ type Handler interface {
 	// SetMaxRepetitions sets the maxRepetitions
 	SetMaxRepetitions(maxRepetitions uint32)
 
-	// NonRepeaters gets the nonRepeaters
-	NonRepeaters() int
-
-	// SetNonRepeaters sets the nonRepeaters
-	SetNonRepeaters(nonRepeaters int)
-
 	// MsgFlags gets the MsgFlags
 	MsgFlags() SnmpV3MsgFlags
 
@@ -283,14 +277,6 @@ func (x *snmpHandler) MaxRepetitions() uint32 {
 // SetMaxRepetitions wraps to 0 at max int32.
 func (x *snmpHandler) SetMaxRepetitions(maxRepetitions uint32) {
 	x.GoSNMP.MaxRepetitions = (maxRepetitions & 0x7FFFFFFF)
-}
-
-func (x *snmpHandler) NonRepeaters() int {
-	return x.GoSNMP.NonRepeaters
-}
-
-func (x *snmpHandler) SetNonRepeaters(nonRepeaters int) {
-	x.GoSNMP.NonRepeaters = nonRepeaters
 }
 
 func (x *snmpHandler) MsgFlags() SnmpV3MsgFlags {

--- a/mocks/gosnmp_mock.go
+++ b/mocks/gosnmp_mock.go
@@ -289,20 +289,6 @@ func (mr *MockHandlerMockRecorder) MsgFlags() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MsgFlags", reflect.TypeOf((*MockHandler)(nil).MsgFlags))
 }
 
-// NonRepeaters mocks base method.
-func (m *MockHandler) NonRepeaters() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NonRepeaters")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// NonRepeaters indicates an expected call of NonRepeaters.
-func (mr *MockHandlerMockRecorder) NonRepeaters() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NonRepeaters", reflect.TypeOf((*MockHandler)(nil).NonRepeaters))
-}
-
 // Port mocks base method.
 func (m *MockHandler) Port() uint16 {
 	m.ctrl.T.Helper()
@@ -483,18 +469,6 @@ func (m *MockHandler) SetMsgFlags(msgFlags gosnmp.SnmpV3MsgFlags) {
 func (mr *MockHandlerMockRecorder) SetMsgFlags(msgFlags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMsgFlags", reflect.TypeOf((*MockHandler)(nil).SetMsgFlags), msgFlags)
-}
-
-// SetNonRepeaters mocks base method.
-func (m *MockHandler) SetNonRepeaters(nonRepeaters int) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetNonRepeaters", nonRepeaters)
-}
-
-// SetNonRepeaters indicates an expected call of SetNonRepeaters.
-func (mr *MockHandlerMockRecorder) SetNonRepeaters(nonRepeaters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonRepeaters", reflect.TypeOf((*MockHandler)(nil).SetNonRepeaters), nonRepeaters)
 }
 
 // SetPort mocks base method.

--- a/walk.go
+++ b/walk.go
@@ -44,7 +44,7 @@ RequestLoop:
 
 		switch getRequestType {
 		case GetBulkRequest:
-			response, err = x.GetBulk([]string{oid}, uint8(x.NonRepeaters), maxReps) //nolint:gosec
+			response, err = x.GetBulk([]string{oid}, 0, maxReps)
 		case GetNextRequest:
 			response, err = x.GetNext([]string{oid})
 		case GetRequest:


### PR DESCRIPTION
Per RFC 1905 4.2.3 (GetBulkRequest-PDU), non-repeaters is a per-request hint, not a global config value. In all internal usage (e.g. walk.go), it was either 0 or detrimental, causing BulkWalk to degrade into Walk behavior.

To maintain API stability, the field is kept but marked as deprecated and ignored.

fixes #518

Reported-by: Daniel Lepage <daniel.lepage@datadoghq.com>