### PR TITLE
Prevent panic during TCP EOF (#521)

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -190,6 +190,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 
 	timeout := x.Timeout
 	withContextDeadline := false
+sendRetry:
 	for retries := 0; ; retries++ {
 		if retries > 0 {
 			if x.OnRetry != nil {
@@ -202,6 +203,9 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 				break
 			}
 			if retries > x.Retries {
+				if err == nil {
+					err = fmt.Errorf("max retries (%d) exceeded", x.Retries)
+				}
 				if strings.Contains(err.Error(), "timeout") {
 					err = fmt.Errorf("request timeout (after %d retries)", retries-1)
 				}
@@ -293,15 +297,12 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 			var resp []byte
 			resp, err = x.receive()
 			if err == io.EOF && strings.HasPrefix(x.Transport, tcp) {
-				// EOF on TCP: reconnect and retry. Do not count
-				// as retry as socket was broken
 				x.Logger.Printf("ERROR: EOF. Performing reconnect")
 				err = x.netConnect()
 				if err != nil {
 					return nil, err
 				}
-				retries--
-				break
+				continue sendRetry
 			} else if err != nil {
 				// receive error. retrying won't help. abort
 				break


### PR DESCRIPTION
When performing SNMP over TCP, a panic could have been triggered due to a nil pointer dereference in marshal.go:send().

The following example could have led to a panic:
- Perform a GET SNMP request over TCP
- Wait for the response in the `waitingResponse` loop
- `(*GoSNMP).receive()` returns io.EOF
- A new tcp connection will be established successfully via `(*GoSNMP).netConnect` and `err` will be set to `nil`
- Break out of the `waitingResponse` loop
- `err == nil` and `result == nil`, because latter would be initialized only after a successful `(*GoSNMP).receive()`
- Reach the "Success!" point and erroneously `return nil, nil`

This will lead to a nil pointer dereference in the calling function `send`.

This patch fixes the bug, by actually performing the retry and continuing the outer retry loop.

The patch also removes the decrementation of the `retries` counter, as this:

> // EOF on TCP: reconnect and retry. Do not count
> // as retry as socket was broken

is seen a legitimate failed request attempt.

Also, remove the decrementation of `retries` here: it could potentially lead to an infinite loop, if reconnecting to the server always succeeds but also always results in an immediate EOF upon receiving the response.

Also, ensure that `err` is always set if the `retries` counter exceeds `(*GoSNMP).Retries.