### PR TITLE
walk(): remove baseOid fallback, default to .1.3.6.1

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -29,9 +29,6 @@ const (
 	// to change this in the GoSNMP struct
 	MaxOids = 60
 
-	// Base OID for MIB-2 defined SNMP variables
-	baseOid = ".1.3.6.1.2.1"
-
 	// Max oid sub-identifier value
 	// https://tools.ietf.org/html/rfc2578#section-7.1.3
 	MaxObjectSubIdentifierValue = 4294967295

--- a/walk.go
+++ b/walk.go
@@ -10,8 +10,15 @@ import (
 )
 
 func (x *GoSNMP) walk(getRequestType PDUType, rootOid string, walkFn WalkFunc) error {
+	// If no rootOid is provided, fall back to the 'internet' subtree (.1.3.6.1).
+	// This ensures visibility of both standard (e.g. MIB-2) and vendor-specific branches.
+	// It also guarantees the OID is valid for BER encoding:
+	// - RFC 2578 §7.1.3: OIDs must have at least two sub-identifiers
+	// - X.690 §8.19: the first two arcs are encoded as (40 * arc1 + arc2)
 	if rootOid == "" || rootOid == "." {
-		rootOid = baseOid
+		// IANA 'internet' subtree under ISO OID structure per X.660.
+		// See https://oidref.com/1.3.6.1
+		rootOid = ".1.3.6.1"
 	}
 
 	if !strings.HasPrefix(rootOid, ".") {


### PR DESCRIPTION
Deprecates the legacy use of baseOid (.1.3.6.1.2.1) in walk(), which previously restricted default walks to MIB-2. When no rootOid is provided, we now default to .1.3.6.1, the IANA-assigned 'internet' subtree, which includes both standard (e.g. MIB-2) and vendor-specific branches. This aligns with X.660 OID structure and Net-SNMP behavior, and avoids encoding errors caused by incomplete OIDs.

Fixes #486

Originally reported by Debianov.