### PR TITLE
Fix SNMPv3 unauthenticated REPORT handling

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -192,6 +192,7 @@ func (x *GoSNMP) sendOneRequest(packetOut *SnmpPacket,
 	withContextDeadline := false
 sendRetry:
 	for retries := 0; ; retries++ {
+		retriedReport := false
 		if retries > 0 {
 			if x.OnRetry != nil {
 				x.OnRetry(x)
@@ -242,6 +243,7 @@ sendRetry:
 
 		packetOut.RequestID = reqID
 
+	resendSameAttempt:
 		if x.Version == Version3 {
 			msgID := (atomic.AddUint32(&(x.msgID), 1) & 0x7FFFFFFF)
 
@@ -333,11 +335,25 @@ sendRetry:
 						useResponseSecurityParameters = true
 					}
 				}
-				err = x.testAuthentication(resp, result, useResponseSecurityParameters)
-				if err != nil {
-					x.Logger.Printf("ERROR on Test Authentication on v3: %s", err)
-					break
+
+				// For noAuth REPORTs, do NOT fail hard in testAuthentication; let payload parsing proceed
+				// so we can see the REPORT and adopt engine params.
+				noAuth := result.MsgFlags == NoAuthNoPriv
+				isReport := false
+
+				if noAuth {
+					if pduTag, ok := peekV3PDUType(resp, cursor, x.Logger); ok {
+						isReport = pduTag == Report
+					}
 				}
+
+				if !(isReport && noAuth) {
+					if err = x.testAuthentication(resp, result, useResponseSecurityParameters); err != nil {
+						x.Logger.Printf("ERROR on Test Authentication on v3: %s", err)
+						break
+					}
+				}
+
 				resp, cursor, err = x.decryptPacket(resp, cursor, result)
 				if err != nil {
 					x.Logger.Printf("ERROR on decryptPacket on v3: %s", err)
@@ -370,20 +386,44 @@ sendRetry:
 			//    or zero if the request identifier cannot be extracted.
 			// - The variable bindings will contain a single object identifier and its value
 			//
-			// usmStatsNotInTimeWindows and usmStatsUnknownEngineIDs are recoverable errors
-			// and will be retransmitted, for others we return the result with an error.
+			// For SNMPv3 REPORT PDUs indicating time/engine sync issues
+			// (usmStatsNotInTimeWindows, usmStatsWrongDigests)
+			// we adopt the authoritative engine params from the REPORT header and
+			// immediately re-marshal and resend once within the same attempt.
+			// Other REPORT OIDs are returned as errors.
 			if result.Version == Version3 && result.PDUType == Report && len(result.Variables) == 1 {
-				switch result.Variables[0].Name {
+				// Adopt authoritative params from the REPORT into the session USM
+				if err := x.storeSecurityParameters(result); err != nil {
+					x.Logger.Printf("SNMPv3: storeSecurityParameters failed: %v", err)
+					return result, err
+				}
+
+				switch oid := result.Variables[0].Name; oid {
 				case usmStatsUnsupportedSecLevels:
 					return result, ErrUnknownSecurityLevel
-				case usmStatsNotInTimeWindows:
-					break waitingResponse
-				case usmStatsUnknownUserNames:
-					return result, ErrUnknownUsername
 				case usmStatsUnknownEngineIDs:
 					break waitingResponse
-				case usmStatsWrongDigests:
-					return result, ErrWrongDigest
+				case usmStatsNotInTimeWindows, usmStatsWrongDigests:
+					// Single immediate resend in this iteration (no Retries consumption)
+					if retriedReport {
+						if oid == usmStatsWrongDigests {
+							return result, ErrWrongDigest
+						}
+						return result, ErrUnknownReportPDU
+					}
+					retriedReport = true
+					// Re-inject the stored authoritative params into the outgoing packet
+					if err := x.updatePktSecurityParameters(packetOut); err != nil {
+						x.Logger.Printf("SNMPv3: updatePktSecurityParameters failed: %v", err)
+						return result, err
+					}
+					// (Optional safety) ensure the packet holds a fresh copy
+					if x.Version == Version3 && x.SecurityParameters != nil {
+						packetOut.SecurityParameters = x.SecurityParameters.Copy()
+					}
+					goto resendSameAttempt
+				case usmStatsUnknownUserNames:
+					return result, ErrUnknownUsername
 				case usmStatsDecryptionErrors:
 					return result, ErrDecryption
 				case snmpUnknownSecurityModels:
@@ -436,7 +476,6 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 		if e := recover(); e != nil {
 			var buf = make([]byte, 8192)
 			runtime.Stack(buf, true)
-
 			err = fmt.Errorf("recover: %v Stack:%v", e, string(buf))
 		}
 	}()
@@ -444,10 +483,10 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 	if x.Conn == nil {
 		return nil, fmt.Errorf("&GoSNMP.Conn is missing. Provide a connection or use Connect()")
 	}
-
 	if x.Retries < 0 {
 		x.Retries = 0
 	}
+
 	x.Logger.Print("SEND INIT")
 	if packetOut.Version == Version3 {
 		x.Logger.Print("SEND INIT NEGOTIATE SECURITY PARAMS")
@@ -457,47 +496,18 @@ func (x *GoSNMP) send(packetOut *SnmpPacket, wait bool) (result *SnmpPacket, err
 		x.Logger.Print("SEND END NEGOTIATE SECURITY PARAMS")
 	}
 
-	// perform request
+	// perform request (handles REPORT resync internally)
 	result, err = x.sendOneRequest(packetOut, wait)
 	if err != nil {
 		x.Logger.Printf("SEND Error on the first Request Error: %s", err)
 		return result, err
 	}
 
-	if result.Version == Version3 {
+	if result.Version == Version3 && result.SecurityParameters != nil {
 		x.Logger.Printf("SEND STORE SECURITY PARAMS from result: %s", result.SecurityParameters.SafeString())
-		err = x.storeSecurityParameters(result)
-
-		if result.PDUType == Report && len(result.Variables) == 1 {
-			switch result.Variables[0].Name {
-			case usmStatsNotInTimeWindows:
-				x.Logger.Print("WARNING detected out-of-time-window ERROR")
-				if err = x.updatePktSecurityParameters(packetOut); err != nil {
-					x.Logger.Printf("ERROR updatePktSecurityParameters error: %s", err)
-					return nil, err
-				}
-				// retransmit with updated auth engine params
-				result, err = x.sendOneRequest(packetOut, wait)
-				if err != nil {
-					x.Logger.Printf("ERROR out-of-time-window retransmit error: %s", err)
-					return result, ErrNotInTimeWindow
-				}
-
-			case usmStatsUnknownEngineIDs:
-				x.Logger.Print("WARNING detected unknown engine id ERROR")
-				if err = x.updatePktSecurityParameters(packetOut); err != nil {
-					x.Logger.Printf("ERROR updatePktSecurityParameters error: %s", err)
-					return nil, err
-				}
-				// retransmit with updated engine id
-				result, err = x.sendOneRequest(packetOut, wait)
-				if err != nil {
-					x.Logger.Printf("ERROR unknown engine id retransmit error: %s", err)
-					return result, ErrUnknownEngineID
-				}
-			}
-		}
+		_ = x.storeSecurityParameters(result) // best-effort; ignore error
 	}
+
 	return result, err
 }
 
@@ -1392,4 +1402,58 @@ func shrinkAndWriteUint(buf io.Writer, in int) error {
 	}
 	_, err = buf.Write(out)
 	return err
+}
+
+// peekV3PDUType peeks the PDUs tag (Report/GetResponse/...) from a v3 message.
+//   - 'cursor' must point to the start of the ScopedPDU (right after v3 header).
+//   - Works only when the ScopedPDU is plaintext (NoPriv). If it's encrypted returns ok=false
+func peekV3PDUType(resp []byte, cursor int, log Logger) (PDUType, bool) {
+	if cursor >= len(resp) {
+		return 0, false
+	}
+	switch PDUType(resp[cursor]) {
+	case PDUType(OctetString):
+		// Encrypted ScopedPDU => cannot peek safely.
+		return 0, false
+	case Sequence:
+		// ScopedPDU is plaintext.
+	default:
+		// Not a valid ScopedPDU start.
+		return 0, false
+	}
+
+	// Skip SEQUENCE header
+	_, hdrLen, err := parseLength(resp[cursor:])
+	if err != nil {
+		log.Printf("peekV3PDUType: parse SEQUENCE err: %v", err)
+		return 0, false
+	}
+	cursor += hdrLen
+	if cursor >= len(resp) {
+		return 0, false
+	}
+
+	// Skip contextEngineID TLV
+	_, consumed, err := parseRawField(log, resp[cursor:], "contextEngineID")
+	if err != nil {
+		log.Printf("peekV3PDUType: parse contextEngineID err: %v", err)
+		return 0, false
+	}
+	cursor += consumed
+	if cursor >= len(resp) {
+		return 0, false
+	}
+
+	// Skip contextName TLV
+	_, consumed, err = parseRawField(log, resp[cursor:], "contextName")
+	if err != nil {
+		log.Printf("peekV3PDUType: parse contextName err: %v", err)
+		return 0, false
+	}
+	cursor += consumed
+	if cursor >= len(resp) {
+		return 0, false
+	}
+
+	return PDUType(resp[cursor]), true
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -18,10 +18,12 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Tests in alphabetical order of function being tested
@@ -2088,4 +2090,209 @@ func dumpBytes2(desc string, bb []byte, cursor int) string {
 		result += fmt.Sprintf(" %02x", b)
 	}
 	return result
+}
+
+func TestSNMPv3_UpdatesEngineTimeOnReport(t *testing.T) {
+	t.Helper()
+
+	// --- Test fixtures -------------------------------------------------------
+	// These are the specific engine times observed in the real UniFi capture.
+	// The client initially believes engineTime=207512 (stale) while the agent
+	// reports 1094073 as the authoritative time through a REPORT PDU.
+	const (
+		engineTimeOld = uint32(207512)  // stale time sent by the client first
+		engineTimeNew = uint32(1094073) // authoritative time from the agent REPORT
+	)
+
+	// Wireshark Frame 2 (UDP payload = SNMP BER message).
+	// This is a REPORT with msgFlags=NoAuthNoPriv and carries the agent’s
+	// authoritative engineBoots/engineTime in the USM header. We inject this
+	// as the server’s first reply to trigger client resync.
+	var deviceReportFrame2 = mustHex(
+		"306d020103301002040c6e214f020205c004010002010304243022040d80001f88801cae0f4e0000001d020101020310b1b9040561646d696e040004003030040d80001f88801cae0f4e0000001d0400a81d02010002010002010030123010060a2b060106030f0101020041021e5d",
+	)
+
+	// Start a mock UDP “device” that:
+	//   1) captures the client's first datagram (should contain engineTimeOld),
+	//   2) replies with the REPORT (above),
+	//   3) captures the client's immediate retry (should contain engineTimeNew).
+	ap := startMockUniFiAP(t, deviceReportFrame2)
+
+	// --- Client setup --------------------------------------------------------
+	// Configure gosnmp to talk to the mock "device" with a stale engineTime.
+	// Retries=0 ensures we’re testing the *inline* REPORT-driven resend (your fix),
+	// not outer retry logic. AuthNoPriv to match the production setup.
+	g := &GoSNMP{
+		Target:        func() string { ip, _ := ap.Addr(); return ip }(),
+		Port:          func() uint16 { _, p := ap.Addr(); return p }(),
+		Transport:     "udp",
+		Version:       Version3,
+		Timeout:       1500 * time.Millisecond, // enough for the two packet round-trip in test
+		Retries:       0,                       // force the inline resend path
+		MsgFlags:      AuthNoPriv,
+		SecurityModel: UserSecurityModel,
+		SecurityParameters: &UsmSecurityParameters{
+			UserName:                 "admin",
+			AuthenticationProtocol:   SHA,
+			AuthenticationPassphrase: "pass",
+			AuthoritativeEngineID:    "80001f8880092003c168aefabc",
+			AuthoritativeEngineBoots: 1,
+			AuthoritativeEngineTime:  engineTimeOld, // seed with stale time
+		},
+	}
+	require.NoError(t, g.Connect(), "Connect")
+	t.Cleanup(func() { _ = g.Conn.Close() })
+
+	// --- Exercise ------------------------------------------------------------
+	// Any v3 request works; we use sysUpTime.0. The mock replies with a REPORT
+	// (NoAuthNoPriv). The client must:
+	//   - skip auth check for that REPORT,
+	//   - parse/adopt authoritative engineBoots/engineTime from its header,
+	//   - immediately resend the *same* request with the corrected time.
+	_, _ = g.Get([]string{"1.3.6.1.2.1.1.3.0"})
+
+	// Give the mock time to receive the client’s *second* write (the inline resend).
+	ap.WaitSecond(2 * time.Second)
+
+	// --- Verify: first write had OLD time -----------------------------------
+	firstWrite := ap.FirstWrite()
+	require.NotEmpty(t, firstWrite, "expected at least 1 client write (initial request)")
+	oldBER := berInt(engineTimeOld) // BER-encoded INTEGER for engineTimeOld
+	require.Truef(t, bytes.Contains(firstWrite, oldBER),
+		"first client write should contain old engineTime %d (BER %x)\nfirst write (hex):\n%s",
+		engineTimeOld, oldBER, hex.Dump(firstWrite))
+
+	// --- Verify: second write exists and has NEW time -----------------------
+	// This proves the inline REPORT handling kicked in and the engine time was updated
+	// *within the same attempt* (no outer retry consumption).
+	secondWrite := ap.SecondWrite()
+	require.NotEmptyf(t, secondWrite,
+		"expected a second client write (inline retry after REPORT), but got only one write\nfirst write (hex):\n%s",
+		hex.Dump(firstWrite))
+
+	newBER := berInt(engineTimeNew) // BER-encoded INTEGER for engineTimeNew
+	assert.Truef(t, bytes.Contains(secondWrite, newBER),
+		"second client write did not update engineTime to %d (BER %x)\nsecond write (hex):\n%s",
+		engineTimeNew, newBER, hex.Dump(secondWrite))
+
+	// Sanity: ensure the old value is *not* still present in the resend.
+	assert.Falsef(t, bytes.Contains(secondWrite, oldBER),
+		"second client write should not still contain old engineTime %d (BER %x)\nsecond write (hex):\n%s",
+		engineTimeOld, oldBER, hex.Dump(secondWrite))
+
+	// --- Verify: session USM state updated ----------------------------------
+	// After processing the REPORT, the client's USM should keep the authoritative
+	// engineTime so future requests are in-window.
+	if usp, ok := g.SecurityParameters.(*UsmSecurityParameters); assert.True(t, ok, "expected UsmSecurityParameters") {
+		assert.Equal(t, engineTimeNew, usp.AuthoritativeEngineTime,
+			"client USM should adopt authoritative engineTime from REPORT")
+	}
+}
+
+// mockUniFiAP simulates a UniFi AP that replies with a v3 REPORT (NoAuthNoPriv)
+// carrying authoritative engine params, then waits for the client’s immediate retry.
+type mockUniFiAP struct {
+	t      *testing.T
+	conn   *net.UDPConn
+	addr   *net.UDPAddr
+	report []byte
+
+	mu          sync.Mutex
+	firstWrite  []byte
+	secondWrite []byte
+	gotSecond   chan struct{}
+}
+
+func startMockUniFiAP(t *testing.T, report []byte) *mockUniFiAP {
+	t.Helper()
+	c, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	require.NoError(t, err, "listen udp")
+
+	m := &mockUniFiAP{
+		t:         t,
+		conn:      c,
+		addr:      c.LocalAddr().(*net.UDPAddr),
+		report:    append([]byte(nil), report...),
+		gotSecond: make(chan struct{}, 1),
+	}
+
+	// single exchange goroutine
+	go m.runOnce()
+	t.Cleanup(func() { _ = m.conn.Close() })
+	return m
+}
+
+func (m *mockUniFiAP) runOnce() {
+	buf := make([]byte, 8192)
+
+	// 1st datagram from client
+	_ = m.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	n, clientAddr, err := m.conn.ReadFromUDP(buf)
+	if err != nil {
+		return
+	}
+	m.mu.Lock()
+	m.firstWrite = append([]byte{}, buf[:n]...)
+	m.mu.Unlock()
+
+	// Send REPORT (authoritative engineTime)
+	_, _ = m.conn.WriteToUDP(m.report, clientAddr)
+
+	// 2nd datagram from client (immediate retry)
+	_ = m.conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n2, _, err2 := m.conn.ReadFromUDP(buf)
+	if err2 == nil {
+		m.mu.Lock()
+		m.secondWrite = append([]byte{}, buf[:n2]...)
+		m.mu.Unlock()
+		m.gotSecond <- struct{}{}
+	}
+}
+
+func (m *mockUniFiAP) Addr() (ip string, port uint16) {
+	return m.addr.IP.String(), uint16(m.addr.Port)
+}
+
+func (m *mockUniFiAP) WaitSecond(d time.Duration) {
+	select {
+	case <-m.gotSecond:
+	case <-time.After(d):
+	}
+}
+
+func (m *mockUniFiAP) FirstWrite() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]byte{}, m.firstWrite...)
+}
+
+func (m *mockUniFiAP) SecondWrite() []byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]byte{}, m.secondWrite...)
+}
+
+// BER INTEGER for positive ints: 0x02 <len> <big-endian>
+func berInt(v uint32) []byte {
+	if v == 0 {
+		return []byte{0x02, 0x01, 0x00}
+	}
+	b := []byte{byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	i := 0
+	for i < len(b)-1 && b[i] == 0x00 {
+		i++
+	}
+	be := b[i:]
+	if be[0]&0x80 != 0 {
+		be = append([]byte{0x00}, be...)
+	}
+	return append([]byte{0x02, byte(len(be))}, be...)
+}
+
+func mustHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }


### PR DESCRIPTION
## Problem

When using SNMPv3 against UniFi APs, [our collector](https://github.com/netdata/netdata) intermittently stopped scraping.

GoSNMP returned:

```
incoming packet is not authentic

```

From Wireshark:

- The client sent requests with a stale `msgAuthoritativeEngineTime = 207512`.
- The device responded with `REPORT PDUs` instead of GetResponses:
   - `msgFlags = 0x00` (NoAuthNoPriv),
   - Authoritative values: `snmpEngineBoots` (same) and `snmpEngineTime = 1094073`.

Instead of adopting the authoritative values and retrying, GoSNMP retried with the same stale engineTime, receiving REPORTs in a loop.


**Why?**

1. **GoSNMP tried to authenticate unauthenticated REPORTs**

   In `sendOneRequest`, GoSNMP always ran `testAuthentication()` before payload parsing. However, according to **RFC 3414 §3.2.7(a)**, an authoritative engine must detect stale times and signal `notInTimeWindow`. **RFC 3414 §11.4** (**Use of Reports**) makes it explicit that such reports may be sent without authentication.

   GoSNMP incorrectly tried to verify authentication even on these unauthenticated REPORTs → failed with "incoming packet is not authentic" → dropped the REPORT.

2. **Engine-time adoption never triggered**

   GoSNMP’s design was: `sendOneRequest` should return the REPORT → `send()` calls `storeSecurityParameters()` to adopt new engineBoots/time → then resend.
Because step (1) failed, the REPORT was dropped, so resync never happened.

## Fix

Verified the fix in our setup (UniFi APs). The problem is resolved ✨ 

---

1. **Skip authentication for unauthenticated REPORTs only**
2. **Handle REPORT-driven resync immediately**

   When `PDUType == Report` and the varbind indicates `usmStatsNotInTimeWindows` or `usmStatsWrongDigests`:

   - Call `storeSecurityParameters(result)` to adopt authoritative engineBoots/time.
   - Call `updatePktSecurityParameters(packetOut)` to refresh the outgoing packet.
   - Immediately `goto resendSameAttempt` to resend within the same attempt (no retry count burned).

3. **Simplify higher-level resend**

   Removed duplicate "on REPORT, update and resend" logic from `send()`.
`sendOneRequest` now fully handles REPORT-driven resync.
`send()` still negotiates initial security params and stores final ones best-effort.
