### PR TITLE
Add numeric oid representation to SnmpPDU

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -196,6 +196,12 @@ type SnmpPDU struct {
 	// Name is an oid in string format eg ".1.3.6.1.4.9.27"
 	Name string
 
+	// NameComponents contains the OID as an array of integers.
+	// For example, ".1.3.6.1" would have NameComponents []uint32{1, 3, 6, 1}.
+	// This avoids consumers needing to re-parse the Name string.
+	// Uses uint32 per RFC 2578 §7.1.3 (sub-identifiers are 0..2^32-1).
+	NameComponents []uint32
+
 	// The type of the value eg Integer
 	Type Asn1BER
 }

--- a/marshal.go
+++ b/marshal.go
@@ -1324,17 +1324,13 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 		}
 
 		// Parse OID
-		rawOid, oidLength, err := parseRawField(x.Logger, packet[cursor:], "OID")
+		oid, oidComponents, oidLength, err := parseRawOID(x.Logger, packet[cursor:])
 		if err != nil {
 			return fmt.Errorf("error parsing OID Value: %w", err)
 		}
 		cursor += oidLength
 		if cursor > len(packet) {
 			return fmt.Errorf("error parsing OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
-		}
-		oid, ok := rawOid.(string)
-		if !ok {
-			return fmt.Errorf("unable to type assert rawOid |%v| to string", rawOid)
 		}
 		x.Logger.Printf("OID: %s", oid)
 		// Parse Value
@@ -1352,7 +1348,7 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("error decoding OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
 		}
 
-		response.Variables = append(response.Variables, SnmpPDU{Name: oid, Type: decodedVal.Type, Value: decodedVal.Value})
+		response.Variables = append(response.Variables, SnmpPDU{Name: oid, NameComponents: oidComponents, Type: decodedVal.Type, Value: decodedVal.Value})
 	}
 	return nil
 }


### PR DESCRIPTION
Related to https://github.com/gosnmp/gosnmp/issues/537

This PR introduces a `NameComponents` field (`[]uint32`) to the `SnmpPDU` struct, storing the pre-parsed OID components. This addresses performance overhead for consumers like `snmp_exporter` that currently have to re-parse the dot-notation `Name` string back into integers for tree-based lookups. By storing the raw integers during the initial decoding phase, we eliminate this redundant parsing step.

Additionally, the OID parsing logic has been updated to use `uint32` instead of `int` or `int64`. This ensures compliance with RFC 2578 (which allows sub-identifiers up to $2^{32}-1$) and prevents potential overflows on 32-bit architectures where `int` is 32-bit signed. The new `parseBase128Uint32` function enforces these limits and correctly handles large sub-identifiers.

The previous `parseBase128Int` function returned `int64` and allowed values exceeding the 32-bit limit specified by the RFC. This could lead to silent overflows or truncation when cast to smaller integer types, particularly on 32-bit systems where `int` is insufficient to hold the full range of valid OID sub-identifiers.

These changes are backward compatible as the existing `Name` field remains unchanged. Tests have been added to verify correct parsing of standard OIDs and to ensure that sub-identifiers exceeding `uint32` limits are correctly rejected.

