### PR TITLE
Add NameComponents to SnmpPDU and optimize OID parsing

### DIFF
--- a/gosnmp.go
+++ b/gosnmp.go
@@ -196,6 +196,12 @@ type SnmpPDU struct {
 	// Name is an oid in string format eg ".1.3.6.1.4.9.27"
 	Name string
 
+	// NameComponents is the OID as a slice of uint32 values, providing
+	// efficient numeric access without string parsing. Per RFC 2578 §7.1.3,
+	// each sub-identifier is constrained to 0..4294967295 (2^32-1).
+	// This field is populated during response unmarshalling.
+	NameComponents []uint32
+
 	// The type of the value eg Integer
 	Type Asn1BER
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -25,6 +25,22 @@ import (
 
 // Tests in alphabetical order of function being tested
 
+// oidStringToComponents converts an OID string like ".1.3.6.1" to []uint32{1, 3, 6, 1}.
+// Used for testing NameComponents population.
+func oidStringToComponents(oid string) []uint32 {
+	oid = strings.TrimPrefix(oid, ".")
+	parts := strings.Split(oid, ".")
+	result := make([]uint32, 0, len(parts))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		v, _ := strconv.ParseUint(p, 10, 32)
+		result = append(result, uint32(v))
+	}
+	return result
+}
+
 // -- Enmarshal ----------------------------------------------------------------
 
 // "Enmarshal" not "Marshal" - easier to select tests via a regex
@@ -848,6 +864,10 @@ func TestUnmarshal(t *testing.T) {
 
 					if vbr.Name != vb.Name {
 						t.Errorf("#%d:%d Name result: %v, test: %v", i, n, vbr.Name, vb.Name)
+					}
+					expectedComponents := oidStringToComponents(vb.Name)
+					if !reflect.DeepEqual(vbr.NameComponents, expectedComponents) {
+						t.Errorf("#%d:%d NameComponents result: %v, expected: %v", i, n, vbr.NameComponents, expectedComponents)
 					}
 					if vbr.Type != vb.Type {
 						t.Errorf("#%d:%d Type result: %v, test: %v", i, n, vbr.Type, vb.Type)


### PR DESCRIPTION
This is a merger of https://github.com/gosnmp/gosnmp/pull/542 and https://github.com/gosnmp/gosnmp/pull/543, which are touching common code. I felt like it'd make life easier to review as a single PR, at perhaps the cost of the PR being a bit broad. Can split if reviewer(s) would prefer more narrow commits/PR.

The PR is implementing a few things:

- Add `NameComponents []uint32` field to `SnmpPDU` for efficient numeric OID access without string parsing. Intent is to prevent a bunch of string -> int slice conversions that are currently necessary in downstream projects like snmp_exporter.
- Replaces `parseBase128Int` with `parseBase128Uint32` to enforce RFC 2578 §7.1.3 uint32 limit (0..4294967295)
- Optimizes `parseObjectIdentifier` using `[]byte` slice with `strconv.AppendUint` instead of `bytes.Buffer`
- Adds VBL pre-allocation in `unmarshalVBL` based on response byte length

