### PR TITLE
Refactor marshal functions with marshalTLV helper

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -418,8 +418,8 @@ func marshalFloat64(v any) ([]byte, error) {
 func marshalLength(length int) ([]byte, error) {
 	// more convenient to pass length as int than uint64. Therefore check < 0
 	if length < 0 {
-		return nil, fmt.Errorf("length must be greater than zero")
-	} else if length < 127 {
+		return nil, fmt.Errorf("length must be >= 0")
+	} else if length <= 127 {
 		return []byte{byte(length)}, nil
 	}
 
@@ -440,6 +440,19 @@ func marshalLength(length int) ([]byte, error) {
 
 	header := []byte{byte(128 | len(bufBytes))}
 	return append(header, bufBytes...), nil
+}
+
+// marshalTLV writes a BER TLV (type-length-value) to buf using proper length
+// encoding. Handles values of any size, including those exceeding 127 bytes.
+func marshalTLV(buf *bytes.Buffer, tag byte, value []byte) error {
+	length, err := marshalLength(len(value))
+	if err != nil {
+		return err
+	}
+	buf.WriteByte(tag)
+	buf.Write(length)
+	buf.Write(value)
+	return nil
 }
 
 func marshalObjectIdentifier(oid string) ([]byte, error) {

--- a/misc_test.go
+++ b/misc_test.go
@@ -26,7 +26,10 @@ var testsMarshalLength = []struct {
 	length   int
 	expected []byte
 }{
+	{0, []byte{0x00}},
 	{1, []byte{0x01}},
+	{127, []byte{0x7f}},
+	{128, []byte{0x81, 0x80}},
 	{129, []byte{0x81, 0x81}},
 	{256, []byte{0x82, 0x01, 0x00}},
 	{272, []byte{0x82, 0x01, 0x10}},


### PR DESCRIPTION
Adds `marshalTLV()` helper to consolidate BER TLV encoding in `marshalVarbind()`. Also fixes incorrect length encoding for OIDs exceeding 127 bytes (rare edge case).

I would like to do a followup performance pass to address some easy wins RE buffer allocs, but figured that it would be harder to review to try and do both at once.

## Problem

The marshaling code had three different patterns for TLV encoding:
1. Hardcoded single-byte length (broken for len > 127)
2. Manual `marshalLength()` calls (correct but verbose)
3. Hardcoded arithmetic (fragile)

Additionally, `marshalLength()` had an off-by-one: length 127 used long form instead of short form.

## Changes

- Add `marshalTLV()` helper in `helper.go`
- Fix `marshalLength()` boundary: `< 127` → `<= 127`
- Refactor all PDU types in `marshalVarbind()` to use `marshalTLV()`
- Refactor `marshalSNMPV1TrapHeader()` enterprise OID encoding

**Affected types**: Integer, Counter32, Gauge32, TimeTicks, Uinteger32, OctetString, BitString, Opaque, ObjectIdentifier, IPAddress, OpaqueFloat, OpaqueDouble, Counter64, NoSuchInstance, NoSuchObject, EndOfMibView

## Real-World Impact

**Low** - the encoding bug only manifests when the OID itself exceeds 127 bytes encoded. Typical OIDs are ~8-50 bytes. The primary value is code consolidation.

## Testing

- `TestMarshalVarbindRoundTrip`: Round-trip tests for all PDU types with small and 128-byte OIDs
- `TestMarshalTLV`: Verifies exact BER length encoding at boundaries (127, 128, 255, 256 bytes)
