### PR TITLE
Update golangci-lint.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,4 +31,4 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --verbose
-          version: v2.7.1
+          version: v2.7.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,7 @@ linters:
     - goprintffuncname
     - gosec
     - misspell
-    # Makes gosec unhappy: https://github.com/golangci/golangci-lint/issues/6237#issuecomment-3616620033
-    # - modernize
+    - modernize
     - nakedret
     - nolintlint
     - revive

--- a/gosnmp.go
+++ b/gosnmp.go
@@ -326,7 +326,7 @@ func (x *GoSNMP) connect(networkSuffix string) error {
 		if err != nil {
 			return fmt.Errorf("error occurred while generating random: %w", err)
 		}
-		x.random = uint32(n.Uint64())
+		x.random = uint32(n.Uint64()) //nolint:gosec
 	}
 	// http://tools.ietf.org/html/rfc3412#section-6 - msgID only uses the first 31 bits
 	// msgID INTEGER (0..2147483647)
@@ -689,7 +689,7 @@ func ToBigInt(value any) *big.Int {
 	case int64:
 		val = value
 	case uint:
-		val = int64(value)
+		val = int64(value) //nolint:gosec
 	case uint8:
 		val = int64(value)
 	case uint16:

--- a/helper.go
+++ b/helper.go
@@ -91,7 +91,7 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 		retVal.Type = Asn1BER(data[0])
 		switch Asn1BER(data[0]) {
 		case Uinteger32:
-			retVal.Value = uint32(ret)
+			retVal.Value = uint32(ret) //nolint:gosec
 		default:
 			retVal.Value = ret
 		}
@@ -275,7 +275,7 @@ func marshalBase128Int(out io.ByteWriter, n int64) (err error) {
 	}
 
 	for i := l - 1; i >= 0; i-- {
-		o := byte(n >> uint(i*7))
+		o := byte(n >> uint(i*7)) //nolint:gosec
 		o &= 0x7f
 		if i != 0 {
 			o |= 0x80
@@ -317,7 +317,7 @@ func marshalInt32(value int) ([]byte, error) {
 	//  b) shall not all be zero
 	// These rules ensure that an integer value is always encoded in the smallest
 	// possible number of octets.
-	val := uint32(value)
+	val := uint32(value) //nolint:gosec
 	switch {
 	case val&mask1 == 0 || val&mask1 == mask1:
 		return []byte{byte(val)}, nil
@@ -364,7 +364,7 @@ func marshalUint32(v any) ([]byte, error) {
 	case uint32:
 		source = val
 	case uint:
-		source = uint32(val)
+		source = uint32(val) //nolint:gosec
 	case uint8:
 		source = uint32(val)
 	case SNMPError:
@@ -599,8 +599,8 @@ func parseInt64(bytes []byte) (int64, error) {
 		ret |= int64(bytes[bytesRead])
 	}
 	// Shift up and down in order to sign extend the result.
-	ret <<= 64 - uint8(len(bytes))*8
-	ret >>= 64 - uint8(len(bytes))*8
+	ret <<= 64 - uint8(len(bytes))*8 //nolint:gosec
+	ret >>= 64 - uint8(len(bytes))*8 //nolint:gosec
 	return ret, nil
 }
 
@@ -805,7 +805,7 @@ func parseUint32(bytes []byte) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	return uint32(ret), nil
+	return uint32(ret), nil //nolint:gosec
 }
 
 // parseUint treats the given bytes as a big-endian, signed integer and returns
@@ -862,14 +862,14 @@ func (b BitStringValue) At(i int) int {
 		return 0
 	}
 	x := i / 8
-	y := 7 - uint(i%8)
+	y := 7 - uint(i%8) //nolint:gosec
 	return int(b.Bytes[x]>>y) & 1
 }
 
 // RightAlign returns a slice where the padding bits are at the beginning. The
 // slice may share memory with the BitString.
 func (b BitStringValue) RightAlign() []byte {
-	shift := uint(8 - (b.BitLength % 8))
+	shift := uint(8 - (b.BitLength % 8)) //nolint:gosec
 	if shift == 8 || len(b.Bytes) == 0 {
 		return b.Bytes
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -523,7 +523,7 @@ func (packet *SnmpPacket) marshalMsg() ([]byte, error) {
 		}
 	} else {
 		// community
-		buf.Write([]byte{4, uint8(len(packet.Community))})
+		buf.Write([]byte{4, uint8(len(packet.Community))}) //nolint:gosec
 		buf.WriteString(packet.Community)
 		// pdu
 		pdu, err2 := packet.marshalPDU()
@@ -1023,7 +1023,7 @@ func (x *GoSNMP) unmarshalVersionFromHeader(packet []byte, response *SnmpPacket)
 
 	if version, ok := rawVersion.(int); ok {
 		x.Logger.Printf("Parsed version %d", version)
-		return SnmpVersion(version), cursor, nil
+		return SnmpVersion(version), cursor, nil //nolint:gosec
 	}
 	return 0, cursor, err
 }
@@ -1119,7 +1119,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 	}
 
 	if requestid, ok := rawRequestID.(int); ok {
-		response.RequestID = uint32(requestid)
+		response.RequestID = uint32(requestid) //nolint:gosec
 		x.Logger.Printf("requestID: %d", response.RequestID)
 	}
 
@@ -1135,7 +1135,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if nonRepeaters, ok := rawNonRepeaters.(int); ok {
-			response.NonRepeaters = uint8(nonRepeaters)
+			response.NonRepeaters = uint8(nonRepeaters) //nolint:gosec
 		}
 
 		// Parse Max Repetitions
@@ -1149,7 +1149,7 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if maxRepetitions, ok := rawMaxRepetitions.(int); ok {
-			response.MaxRepetitions = uint32(maxRepetitions & 0x7FFFFFFF)
+			response.MaxRepetitions = uint32(maxRepetitions & 0x7FFFFFFF) //nolint:gosec
 		}
 	} else {
 		// Parse Error-Status
@@ -1163,8 +1163,8 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if errorStatus, ok := rawError.(int); ok {
-			response.Error = SNMPError(errorStatus)
-			x.Logger.Printf("errorStatus: %d", uint8(errorStatus))
+			response.Error = SNMPError(errorStatus)                //nolint:gosec
+			x.Logger.Printf("errorStatus: %d", uint8(errorStatus)) //nolint:gosec
 		}
 
 		// Parse Error-Index
@@ -1178,8 +1178,8 @@ func (x *GoSNMP) unmarshalResponse(packet []byte, response *SnmpPacket) error {
 		}
 
 		if errorindex, ok := rawErrorIndex.(int); ok {
-			response.ErrorIndex = uint8(errorindex)
-			x.Logger.Printf("error-index: %d", uint8(errorindex))
+			response.ErrorIndex = uint8(errorindex)               //nolint:gosec
+			x.Logger.Printf("error-index: %d", uint8(errorindex)) //nolint:gosec
 		}
 	}
 

--- a/trap.go
+++ b/trap.go
@@ -72,7 +72,7 @@ func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
 		}
 
 		if trap.Variables[0].Type != TimeTicks {
-			now := uint32(time.Now().Unix())
+			now := uint32(time.Now().Unix()) //nolint:gosec
 			timetickPDU := SnmpPDU{Name: "1.3.6.1.2.1.1.3.0", Type: TimeTicks, Value: now}
 			// prepend timetickPDU
 			trap.Variables = append([]SnmpPDU{timetickPDU}, trap.Variables...)

--- a/v3.go
+++ b/v3.go
@@ -378,7 +378,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if MsgID, ok := rawMsgID.(int); ok {
-		response.MsgID = uint32(MsgID)
+		response.MsgID = uint32(MsgID) //nolint:gosec
 		x.Logger.Printf("Parsed message ID %d", MsgID)
 	}
 
@@ -392,7 +392,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if MsgMaxSize, ok := rawMsgMaxSize.(int); ok {
-		response.MsgMaxSize = uint32(MsgMaxSize)
+		response.MsgMaxSize = uint32(MsgMaxSize) //nolint:gosec
 		x.Logger.Printf("Parsed message max size %d", MsgMaxSize)
 	}
 
@@ -420,7 +420,7 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	}
 
 	if SecModel, ok := rawSecModel.(int); ok {
-		response.SecurityModel = SnmpV3SecurityModel(SecModel)
+		response.SecurityModel = SnmpV3SecurityModel(SecModel) //nolint:gosec
 		x.Logger.Printf("Parsed security model %d", SecModel)
 	}
 

--- a/v3_usm.go
+++ b/v3_usm.go
@@ -737,9 +737,9 @@ func digestRFC3414(h SnmpV3AuthProtocol, packet []byte, authKey []byte) ([]byte,
 		h2 = sha1.New() //nolint:gosec
 	}
 
-	for i := 0; i < 64; i++ {
-		k1[i] = extkey[i] ^ 0x36
-		k2[i] = extkey[i] ^ 0x5c
+	for i := range 64 {
+		k1[i] = extkey[i] ^ 0x36 //nolint:gosec
+		k2[i] = extkey[i] ^ 0x5c //nolint:gosec
 	}
 
 	_, err = h1.Write(k1[:])
@@ -837,8 +837,8 @@ func (sp *UsmSecurityParameters) encryptPacket(scopedPdu []byte) ([]byte, error)
 	case DES:
 		preiv := sp.PrivacyKey[8:]
 		var iv [8]byte
-		for i := 0; i < len(iv); i++ {
-			iv[i] = preiv[i] ^ sp.PrivacyParameters[i]
+		for i := range len(iv) {
+			iv[i] = preiv[i] ^ sp.PrivacyParameters[i] //nolint:gosec
 		}
 		block, err := des.NewCipher(sp.PrivacyKey[:8]) //nolint:gosec
 		if err != nil {
@@ -895,8 +895,8 @@ func (sp *UsmSecurityParameters) decryptPacket(packet []byte, cursor int) ([]byt
 		}
 		preiv := sp.PrivacyKey[8:]
 		var iv [8]byte
-		for i := 0; i < len(iv); i++ {
-			iv[i] = preiv[i] ^ sp.PrivacyParameters[i]
+		for i := range len(iv) {
+			iv[i] = preiv[i] ^ sp.PrivacyParameters[i] //nolint:gosec
 		}
 		block, err := des.NewCipher(sp.PrivacyKey[:8]) //nolint:gosec
 		if err != nil {
@@ -1017,7 +1017,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	}
 	cursor += count
 	if AuthoritativeEngineBoots, ok := rawMsgAuthoritativeEngineBoots.(int); ok {
-		sp.AuthoritativeEngineBoots = uint32(AuthoritativeEngineBoots)
+		sp.AuthoritativeEngineBoots = uint32(AuthoritativeEngineBoots) //nolint:gosec
 		sp.Logger.Printf("Parsed authoritativeEngineBoots %d", AuthoritativeEngineBoots)
 	}
 
@@ -1027,7 +1027,7 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 	}
 	cursor += count
 	if AuthoritativeEngineTime, ok := rawMsgAuthoritativeEngineTime.(int); ok {
-		sp.AuthoritativeEngineTime = uint32(AuthoritativeEngineTime)
+		sp.AuthoritativeEngineTime = uint32(AuthoritativeEngineTime) //nolint:gosec
 		sp.Logger.Printf("Parsed authoritativeEngineTime %d", AuthoritativeEngineTime)
 	}
 


### PR DESCRIPTION
Update golangci-lint to fix bugs in gosec linter.
* Re-add `nolint:gosec` removed in #536 due to buggy gosec linter.
* Enable `modernize` now that gosec is fixed.