### PR TITLE
Marshal helpers - optimization: reduce allocations in OID, float, and length encoding 

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -770,3 +770,145 @@ func TestIPAddressParseRawField(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshalFloat32(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "zero",
+			input:   float32(0.0),
+			want:    []byte{0x00, 0x00, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "positive 1.0",
+			input:   float32(1.0),
+			want:    []byte{0x3f, 0x80, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "negative 1.0",
+			input:   float32(-1.0),
+			want:    []byte{0xbf, 0x80, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "pi approx",
+			input:   float32(3.14159),
+			want:    []byte{0x40, 0x49, 0x0f, 0xd0},
+			wantErr: false,
+		},
+		{
+			name:    "wrong type int",
+			input:   42,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type float64",
+			input:   float64(1.0),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type string",
+			input:   "1.0",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := marshalFloat32(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("marshalFloat32() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("marshalFloat32() unexpected error: %v", err)
+				return
+			}
+			if !checkByteEquality2(got, tt.want) {
+				t.Errorf("marshalFloat32() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "zero",
+			input:   float64(0.0),
+			want:    []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "positive 1.0",
+			input:   float64(1.0),
+			want:    []byte{0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "negative 1.0",
+			input:   float64(-1.0),
+			want:    []byte{0xbf, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantErr: false,
+		},
+		{
+			name:    "pi approx",
+			input:   float64(3.141592653589793),
+			want:    []byte{0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18},
+			wantErr: false,
+		},
+		{
+			name:    "wrong type int",
+			input:   42,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type float32",
+			input:   float32(1.0),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "wrong type string",
+			input:   "1.0",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := marshalFloat64(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("marshalFloat64() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("marshalFloat64() unexpected error: %v", err)
+				return
+			}
+			if !checkByteEquality2(got, tt.want) {
+				t.Errorf("marshalFloat64() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a follow-up PR to https://github.com/gosnmp/gosnmp/pull/548, to do a performance optimization pass. It seemed like too much scope creep to include in that refactor.

This is intended to be an (almost) purely performance-oriented PR - aiming to improve performance in these frequently called code paths.

it follows some similar patterns to https://github.com/gosnmp/gosnmp/pull/547

A minor behavioral change was included with `marshalFloat32` / `marshalFloat64` type checks, and some additional tests. 

## Changes

### `marshalObjectIdentifier`
- Replace `bytes.Buffer` with pre-allocated `[]byte` slice
- Refactor `marshalBase128Int(io.ByteWriter) error` → `appendBase128Int([]byte) []byte`
- Capacity heuristic `oidLength/2` based on worst-case encoding ratio

### `marshalFloat32` / `marshalFloat64`
- Replace `bytes.Buffer` + `binary.Write` with direct byte manipulation using `math.Float32bits`/`math.Float64bits`
- Add checked type assertions that return errors instead of panicking on wrong input type

### `marshalLength`
- Replace `bytes.Buffer` + `binary.Write` with stack-allocated `[8]byte` array
- Minor: refactor `else if` to separate `if` statements

## Benchmark Results

Tested on `go1.25.5 linux/amd64`  (AMD Ryzen 9 7940HS).

### marshalObjectIdentifier

Using existing `BenchmarkMarshalObjectIdentifier` (OID: `.1.3.6.3.30.11.1.10`):

|  | Before | After |
|--|--------|-------|
| Speed | 77 ns/op | 42 ns/op |
| Memory | 112 B/op | 16 B/op |
| Allocs | 2 | 1 |

### marshalFloat32 / marshalFloat64

|  | Before | After |
|--|--------|-------|
| Float32 speed | 51 ns/op | 7.6 ns/op |
| Float64 speed | 53 ns/op | 8.5 ns/op |
| Float32 mem | 116 B/op | 4 B/op |
| Float64 mem | 120 B/op | 8 B/op |
| Allocs | 3 | 1 |

### marshalLength (long form, length=435)

|  | Before | After |
|--|--------|-------|
| Speed | 75 ns/op | 10 ns/op |
| Memory | 136 B/op | 3 B/op |
| Allocs | 5 | 1 |

## Benchmark code

Benchmark code for float/length (not included in PR):

https://gist.github.com/lukeod/d2059f17c1bb33c660d57b0afa542eb5

I'm assuming that we don't want to pollute the tests with a bunch of benchmarks, but am happy to amend the PR to include if preferred.  

## Testing

- Added `TestMarshalFloat32` / `TestMarshalFloat64` for correctness and error handling
