### PR TITLE
Fix walk loop detection to catch decreasing OIDs

### DIFF
--- a/walk_test.go
+++ b/walk_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 The GoSNMP Authors. All rights reserved.  Use of this
+// source code is governed by a BSD-style license that can be found in the
+// LICENSE file.
+
+//go:build all || walk
+
+package gosnmp
+
+import "testing"
+
+func TestOidCompare(t *testing.T) {
+	tests := []struct {
+		name     string
+		oid1     string
+		oid2     string
+		expected int
+	}{
+		// oid1 == oid2 (returns 0)
+		{"equal", ".1.3.6.1", ".1.3.6.1", 0},
+		{"equal ignores leading dot", ".1.3.6.1", "1.3.6.1", 0},
+
+		// oid1 < oid2 (returns -1)
+		{"less by component value", ".1.3.6.1", ".1.3.6.2", -1},
+		{"less by length", ".1.3.6.1", ".1.3.6.1.4", -1},
+		{"less by numeric not string order", ".1.3.6.1.2", ".1.3.6.1.10", -1},
+		{"less at uint32 max", ".1.3.4294967294", ".1.3.4294967295", -1},
+		{"empty less than any oid", "", ".1.3.6.1", -1},
+
+		// oid1 > oid2 (returns 1)
+		{"greater by component value", ".1.3.6.2", ".1.3.6.1", 1},
+		{"greater when response decreases", ".1.3.6.1.4.1.2636.3.60.1.2.1.1.6.578.227", ".1.3.6.1.4.1.2636.3.60.1.2.1.1.6.578.0", 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oidCompare(tc.oid1, tc.oid2)
+			if got != tc.expected {
+				t.Errorf("oidCompare(%q, %q) = %d, want %d", tc.oid1, tc.oid2, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR aims to improve the `checkIncreasing` logic in Walk/BulkWalk to handle cases where SNMP agents return decreasing OIDs. 

The existing check only detects when the response OID is exactly equal to the request OID. When a non-compliant/buggy agent returns an OID smaller than the previous request, like:

`
.1.1.1
.1.1.2
.1.1.1
<potentially repeated forever>
`
The walk loops indefinitely through a range of OIDs.

This change replaces the equality check with a proper ordering comparison (matching net-snmp's `snmp_oid_compare` in `snmplib/snmp_api.c:7031-7070`), terminating the walk when the response OID is less than or equal to the request OID.

Related to #401, and possibly #498. It's a fix in so far as it handles those cases better - erroring immediately. 

Currently, it is probably the case that these loops cause a sort of "snmp storm / DoS" condition that has to be handled more gracefully in the downstream application, or via "dumb" timeouts.

## Changes

- Add `oidCompare(oid1, oid2 string) int` function returning -1/0/1
- Add `nextOIDComponent` helper for zero-allocation OID parsing
- Change walk check from `pdu.Name == oid` to `oidCompare(oid, pdu.Name) >= 0`
- Improve error message to show both OIDs: `OID not increasing: X >= Y`
- Add tests for OID comparison (equality, ordering, numeric vs string order, uint32 bounds)

## Implementation Notes

The `oidCompare` function uses inline parsing similar to net-snmp rather than converting OIDs to integer slices first. This is more complex than a simple slice comparison, however results in zero allocations. It's very much in the hot path during walks, as the check runs once per PDU (potentially thousands of times in a single walk).

Placed the functions in walk.go rather than helper.go, as it seems pretty specific to walks. Happy to move if preferred. 