### PR TITLE
Bound varbind parsing to SEQUENCE length and validate value TLV structure

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1231,7 +1231,7 @@ func (x *GoSNMP) unmarshalTrapV1(packet []byte, response *SnmpPacket) error {
 
 // unmarshal a Varbind list
 func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
-	var cursor, cursorInc int
+	var cursor int
 	var vblLength int
 
 	if len(packet) == 0 || cursor > len(packet) {
@@ -1266,43 +1266,46 @@ func (x *GoSNMP) unmarshalVBL(packet []byte, response *SnmpPacket) error {
 			return fmt.Errorf("expected a sequence when unmarshalling a VB, got %x", packet[cursor])
 		}
 
-		_, cursorInc, err = parseLength(packet[cursor:])
+		vbLength, cursorInc, err := parseLength(packet[cursor:])
 		if err != nil {
 			return err
 		}
-		cursor += cursorInc
-		if cursor > len(packet) {
-			return fmt.Errorf("error parsing OID Value: packet %d cursor %d", len(packet), cursor)
+		vbEnd := cursor + vbLength
+		if vbEnd > vblLength {
+			return fmt.Errorf("varbind SEQUENCE length exceeds remaining VBL (vbEnd %d, vblLength %d)", vbEnd, vblLength)
 		}
+		cursor += cursorInc
 
 		// Parse OID
-		rawOid, oidLength, err := parseRawField(x.Logger, packet[cursor:], "OID")
+		rawOid, oidLength, err := parseRawField(x.Logger, packet[cursor:vbEnd], "OID")
 		if err != nil {
 			return fmt.Errorf("error parsing OID Value: %w", err)
 		}
 		cursor += oidLength
-		if cursor < 0 || cursor > len(packet) {
-			return fmt.Errorf("error parsing OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
-		}
+
 		oid, ok := rawOid.(string)
 		if !ok {
 			return fmt.Errorf("unable to type assert rawOid |%v| to string", rawOid)
 		}
 		x.Logger.Printf("OID: %s", oid)
+
+		// Validate value TLV fills remaining varbind body exactly
+		valueSlice := packet[cursor:vbEnd]
+		valueLength, _, err := parseLength(valueSlice)
+		if err != nil {
+			return fmt.Errorf("error parsing value TLV in varbind: %w", err)
+		}
+		if valueLength != len(valueSlice) {
+			return fmt.Errorf("value TLV length mismatch in varbind (TLV %d, remaining %d)", valueLength, len(valueSlice))
+		}
+
 		// Parse Value
 		var decodedVal variable
-		if err = x.decodeValue(packet[cursor:], &decodedVal); err != nil {
+		if err = x.decodeValue(valueSlice, &decodedVal); err != nil {
 			return fmt.Errorf("error decoding value: %w", err)
 		}
 
-		valueLength, _, err := parseLength(packet[cursor:])
-		if err != nil {
-			return err
-		}
-		cursor += valueLength
-		if cursor < 0 || cursor > len(packet) {
-			return fmt.Errorf("error decoding OID Value: truncated, packet length %d cursor %d", len(packet), cursor)
-		}
+		cursor = vbEnd
 
 		response.Variables = append(response.Variables, SnmpPDU{Name: oid, Type: decodedVal.Type, Value: decodedVal.Value})
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2396,27 +2396,22 @@ func TestUnmarshalVBL(t *testing.T) {
 		{"empty_VBL_short_form", []byte{0x30, 0x00}, false, 0, nil},
 		{"empty_VBL_long_form_BER", []byte{0x30, 0x82, 0x00, 0x00}, false, 0, nil},
 
-		// Malformed value length
-		{"bad_OctetString_length,valid", buildVBL(badVB(0x01, OctetString, []byte("test"), 5), goodVB(0x02, OctetString, []byte("data"))), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, append([]byte("test"), 0x30)}}},
-		{"bad_Integer_length,valid", buildVBL(badVB(0x01, Integer, []byte{0x01}, 3), goodVB(0x02, OctetString, []byte("data"))), true, 1,
-			[]wantPDU{{".1.3.6.1", Integer, 77835}}},
-		{"bad_Counter32_length,valid", buildVBL(badVB(0x01, Counter32, []byte{0x00, 0x00, 0x00, 0x2a}, 5), goodVB(0x02, OctetString, []byte("data"))), true, 1,
-			[]wantPDU{{".1.3.6.1", Counter32, uint(10800)}}},
+		// Malformed value length — bounded parsing catches errors within the
+		// offending varbind, preventing cross-varbind data leakage.
+		{"bad_OctetString_length,valid", buildVBL(badVB(0x01, OctetString, []byte("test"), 5), goodVB(0x02, OctetString, []byte("data"))), true, 0, nil},
+		{"bad_Integer_length,valid", buildVBL(badVB(0x01, Integer, []byte{0x01}, 3), goodVB(0x02, OctetString, []byte("data"))), true, 0, nil},
+		{"bad_Counter32_length,valid", buildVBL(badVB(0x01, Counter32, []byte{0x00, 0x00, 0x00, 0x2a}, 5), goodVB(0x02, OctetString, []byte("data"))), true, 0, nil},
 		{"bad_length_last", buildVBL(badVB(0x01, OctetString, []byte("test"), 5)), true, 0, nil},
-		{"bad_length_long_form_BER,valid", buildVBL(badVB(0x01, OctetString, largeContent, 201), goodVB(0x02, OctetString, []byte("ok"))), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, append(append([]byte{}, largeContent...), 0x30)}}},
+		{"bad_length_long_form_BER,valid", buildVBL(badVB(0x01, OctetString, largeContent, 201), goodVB(0x02, OctetString, []byte("ok"))), true, 0, nil},
 		{"large_OctetString_off_by_one_last", buildVBL(badVB(0x01, OctetString, largeString, 448)), true, 0, nil},
-		{"large_OctetString_off_by_one,valid", buildVBL(badVB(0x01, OctetString, largeString, 448), goodVB(0x02, OctetString, []byte("ok"))), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, append(append([]byte{}, largeString...), 0x30)}}},
+		{"large_OctetString_off_by_one,valid", buildVBL(badVB(0x01, OctetString, largeString, 448), goodVB(0x02, OctetString, []byte("ok"))), true, 0, nil},
 
 		// Malformed varbind at different positions
 		{"valid,bad", buildVBL(goodVB(0x01, OctetString, []byte("good")), badVB(0x02, OctetString, []byte("bad"), 10)), true, 1,
 			[]wantPDU{{".1.3.6.1", OctetString, []byte("good")}}},
-		{"valid,bad,valid", buildVBL(goodVB(0x01, OctetString, []byte("first")), badVB(0x02, OctetString, []byte("x"), 5), goodVB(0x03, OctetString, []byte("third"))), true, 2,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte("first")}, {".1.3.6.2", OctetString, []byte{0x78, 0x30, 0x0c, 0x06, 0x03}}}},
-		{"bad,bad,valid", buildVBL(badVB(0x01, OctetString, []byte("a"), 5), badVB(0x02, OctetString, []byte("b"), 5), goodVB(0x03, OctetString, []byte("ok"))), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte{0x61, 0x30, 0x08, 0x06, 0x03}}}},
+		{"valid,bad,valid", buildVBL(goodVB(0x01, OctetString, []byte("first")), badVB(0x02, OctetString, []byte("x"), 5), goodVB(0x03, OctetString, []byte("third"))), true, 1,
+			[]wantPDU{{".1.3.6.1", OctetString, []byte("first")}}},
+		{"bad,bad,valid", buildVBL(badVB(0x01, OctetString, []byte("a"), 5), badVB(0x02, OctetString, []byte("b"), 5), goodVB(0x03, OctetString, []byte("ok"))), true, 0, nil},
 
 		// Malformed OID
 		{"garbage_OID_tag", buildVBL(buildSequence([]byte{0xFF, 0x03, 0xDE, 0xAD, 0xBE}), goodVB(0x01, OctetString, []byte("ok"))), true, 0, nil},
@@ -2426,21 +2421,29 @@ func TestUnmarshalVBL(t *testing.T) {
 		{"zero_length_OID", buildVBL(buildSequence(append([]byte{0x06, 0x00}, 0x04, 0x04, 0x74, 0x65, 0x73, 0x74))), true, 0, nil},
 
 		// Trailing bytes inside varbind body (value TLV doesn't fill SEQUENCE)
-		{"trailing_junk_after_Null", buildVBL(rawVB(0x01, []byte{0x05, 0x00, 0xFF})), true, 1,
-			[]wantPDU{{".1.3.6.1", Null, nil}}},
-		{"trailing_junk_after_OctetString", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0xFF})), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte{0x41}}}},
-		{"multiple_value_TLVs", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0x02, 0x01, 0x01})), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte{0x41}}}},
-		{"short_value_with_padding", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0x00, 0x00})), true, 1,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte{0x41}}}},
-		{"valid,trailing_junk", buildVBL(goodVB(0x01, OctetString, []byte("ok")), rawVB(0x02, []byte{0x05, 0x00, 0xFF})), true, 2,
-			[]wantPDU{{".1.3.6.1", OctetString, []byte("ok")}, {".1.3.6.2", Null, nil}}},
+		// Structural validation rejects these before decodeValue runs.
+		{"trailing_junk_after_Null", buildVBL(rawVB(0x01, []byte{0x05, 0x00, 0xFF})), true, 0, nil},
+		{"trailing_junk_after_OctetString", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0xFF})), true, 0, nil},
+		{"multiple_value_TLVs", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0x02, 0x01, 0x01})), true, 0, nil},
+		{"short_value_with_padding", buildVBL(rawVB(0x01, []byte{0x04, 0x01, 0x41, 0x00, 0x00})), true, 0, nil},
+		{"valid,trailing_junk", buildVBL(goodVB(0x01, OctetString, []byte("ok")), rawVB(0x02, []byte{0x05, 0x00, 0xFF})), true, 1,
+			[]wantPDU{{".1.3.6.1", OctetString, []byte("ok")}}},
 
 		// Unknown type
 		{"unknown_type_well_formed", buildVBL(rawVB(0x01, []byte{0xC0, 0x02, 0x01, 0x02})), false, 1,
 			[]wantPDU{{".1.3.6.1", UnknownType, nil}}},
 		{"unknown_type_malformed_length", buildVBL(rawVB(0x01, []byte{0xC0, 0x05})), true, 0, nil},
+
+		// Varbind SEQUENCE length exceeds VBL boundary
+		{"varbind_sequence_exceeds_VBL", func() []byte {
+			vbl := buildVBL(goodVB(0x01, OctetString, []byte("test")))
+			vbl[3] += 10
+			return vbl
+		}(), true, 0, nil},
+
+		// Cross-varbind data leakage: bounded parsing prevents value from
+		// reading past varbind SEQUENCE boundary into adjacent varbind data.
+		{"cross_contamination", buildVBL(badVB(0x01, OctetString, []byte("AAAA"), 5), goodVB(0x02, OctetString, []byte("SECRET"))), true, 0, nil},
 	}
 
 	for _, tt := range tests {
@@ -2459,41 +2462,5 @@ func TestUnmarshalVBL(t *testing.T) {
 				assertPDUs(t, vars, tt.wantPDUs)
 			}
 		})
-	}
-}
-
-func TestUnmarshalVBLVarbindSequenceExceedsVBL(t *testing.T) {
-	// Varbind SEQUENCE length extends past VBL boundary.
-	vbl := buildVBL(goodVB(0x01, OctetString, []byte("test")))
-	vbl[3] += 10
-
-	vars, err := testUnmarshalVBL(t, vbl)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if len(vars) != 1 {
-		t.Errorf("expected 1 variable, got %d", len(vars))
-	}
-}
-
-func TestUnmarshalVBLCrossContamination(t *testing.T) {
-	// Value declares 5 bytes but has 4, followed by a valid varbind.
-	// Without bounded parsing, decodeValue reads 1 byte from the next
-	// varbind (the 0x30 SEQUENCE tag), producing cross-varbind leakage.
-	packet := buildVBL(badVB(0x01, OctetString, []byte("AAAA"), 5), goodVB(0x02, OctetString, []byte("SECRET")))
-	vars, err := testUnmarshalVBL(t, packet)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if len(vars) != 1 {
-		t.Fatalf("expected 1 variable, got %d", len(vars))
-	}
-	val, ok := vars[0].Value.([]byte)
-	if !ok {
-		t.Fatalf("expected []byte value, got %T", vars[0].Value)
-	}
-	// The leaked byte is 0x30 (next varbind's SEQUENCE tag).
-	if len(val) != 5 || val[4] != 0x30 {
-		t.Errorf("expected 5 bytes with trailing 0x30, got %x", val)
 	}
 }


### PR DESCRIPTION
Follow-up to #566 and #570. Uses the varbind SEQUENCE length - currently parsed but discarded - to bound inner parsing and validate that the value TLV fills the remaining varbind body.

### Problem

Some devices (notably MikroTik) return varbinds where the value's BER length is slightly larger than what fits within the enclosing varbind SEQUENCE. For example, a value declaring 3 content bytes when only 2 remain in the SEQUENCE:

```
VarBindList SEQUENCE (length=30)
├─ VarBind SEQUENCE (length=14)       <- vbLength: bounds this varbind
│  ├─ OID    0x06 (length=8)  [10 bytes total]
│  └─ value  0x04 (length=3)  [ 5 bytes total]   <- declares 3, but should be 2 per varbind length
├─ VarBind SEQUENCE (length=12)
│  ├─ OID    0x06 (length=8)
│  └─ value  0x05 (length=0)
```

This is the pattern behind the various issues reported (prometheus/snmp_exporter#1312, prometheus/snmp_exporter#1515, prometheus/snmp_exporter#1182) - a MikroTik OctetString with BER length off by 1 byte (firmware bug).

There are a few options for handling this:

1. **Read past the varbind boundary** (current gosnmp behavior). `unmarshalVBL` discards the SEQUENCE length and passes `packet[cursor:]` (all remaining VBL bytes) to `decodeValue`. The value parser reads the extra byte from the next varbind's data, and the cursor lands mid-header of the next varbind, producing `"expected a sequence when unmarshalling a VB, got XX"`. The bad varbind itself appears to parse "successfully" and is returned, but its value contains leaked bytes from the adjacent varbind's header. Varbinds before the bad one are also returned, but everything after it is lost.

2. **Read past the varbind boundary, but advance cursor correctly** (net-snmp's approach). `snmp_parse_var_op` uses the SEQUENCE length to advance between varbinds, so subsequent varbinds parse correctly. But value parsers receive `SNMP_MAX_PACKET_LEN` as their length limit, so they silently read the extra byte from across the boundary - the value contains wrong data borrowed from the adjacent varbind, but parsing continues. This keeps things running, but the value is silently corrupt - it's hard to see consuming bytes from an adjacent varbind's header as correct behavior, so this PR isn't proposing to match net-snmp behavior.

3. **Bound to SEQUENCE length, reject the bad varbind** (this PR). Use the SEQUENCE length to bound both OID and value parsing. The value TLV must exactly fill the remaining SEQUENCE body. A length mismatch is an error - `unmarshalVBL` returns on first failure, so varbinds before the bad one are returned alongside the error, and varbinds after it are lost. The improvement over option 1 is that the error is clean, attributable to the right varbind, and no cross-boundary data leakage occurs.

4. **Bound to SEQUENCE length, skip bad varbinds and continue**. Same bounding as option 3, but on inner parse failure, advance cursor to `vbEnd` and continue the loop instead of aborting. The bad varbind is discarded but the rest of the response is preserved. The bounded parsing is what makes this safe - we know exactly where the next varbind starts regardless of what went wrong inside the current one.

5. **Bound to SEQUENCE length, clamp to available bytes**. Same bounding as option 3, but when a value TLV declares more bytes than remain in the SEQUENCE, clamp to available bytes instead of erroring. Nothing is discarded - the assumption is that the value's BER length field is wrong but the actual data is present within the varbind SEQUENCE in its entirety, so we trust the SEQUENCE boundary over the value length. Trailing junk (value shorter than remaining space) still rejected.

This PR implements option 3, which is the structural foundation that enables options 4 and 5. We don't change much behaviorally, pretty much just catching the error earlier and attributing it better.

We can then look at options 4 or 5 in a follow-up pr, either of which would effectively "solve" that mikrotik issue as far as most users are concerned. Rolling that policy / permissiveness change into this PR seemed like expanding what is already a non-trivial PR to review.

Happy to discuss which direction to go for follow-up behavior - both are straightforward to layer on top of this. It's worth noting that if we *do* want to just implement exactly what net-snmp does, then this PR as it stands is probably not ideal, as passing bounded slices would prevent reading those "extra" bytes.

### Changes

- Capture `vbLength` from the varbind SEQUENCE header (previously discarded with `_`)
- Validate `vbEnd` doesn't exceed VBL length
- Pass bounded slices `packet[cursor:vbEnd]` to `parseRawField` (OID) and `decodeValue`
- After OID parsing, validate that the value TLV exactly fills the remaining varbind body - rejects trailing junk, padding, and extra TLVs
- Advance cursor via `cursor = vbEnd` instead of a redundant second `parseLength` on the value TLV
- Remove overflow checks made unnecessary by the bounded slice

### Behavioral changes

All changes only affect malformed packets. Well-formed packets parse identically.

- **Cross-varbind data leakage**: eliminated. A bad value length is caught within its own varbind rather than corrupting the next. Tests like `bad_OctetString_length,valid` now return 0 vars instead of 1 var containing leaked cross-boundary data. If a caller was swallowing the error and using the partial data, they would see one fewer varbind - but the one they were getting before contained bytes from the adjacent varbind's header, not real data.
- **Varbind SEQUENCE exceeding VBL**: now rejected. Previously the SEQUENCE length was discarded, so this was invisible - the parser would read the inner TLVs using their own lengths and succeed as long as they were internally consistent. Now that the SEQUENCE length is used for bounding, a varbind that claims to be larger than the remaining VBL is caught. net-snmp also rejects this case (`asn_parse_nlength` validates that the parsed length doesn't exceed available buffer bytes). This would require a device to emit a correct inner structure but a wrong SEQUENCE length, which is unlikely in practice.
- **Trailing junk inside varbind body**: now rejected with a value TLV length mismatch error. Previously these were accidentally detected when `parseLength` advanced cursor past the value TLV and the junk bytes failed the next-loop `0x30` sequence check - the error messages were confusing (`"expected a sequence when unmarshalling a VB"`) but the rejection was correct. The new errors are explicit.
