### PR TITLE
Fix first OID sub-identifier to use base-128 decoding

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -692,14 +692,24 @@ func parseObjectIdentifier(src []byte) (string, error) {
 	// Worst-case: first byte expands to 5 chars (".2.39"), rest to 4 chars (".127")
 	out := make([]byte, 0, len(src)*4+1)
 
+	// First sub-identifier encodes arc1 and arc2 as (arc1*40 + arc2);
+	// arc1 is 0, 1, or 2, with arc2 <= 39 when arc1 < 2.
+	// Remaining arcs are encoded individually.
+	v, offset, err := parseBase128Uint32(src, 0)
+	if err != nil {
+		return "", err
+	}
 	out = append(out, '.')
-	out = strconv.AppendUint(out, uint64(src[0]/40), 10)
-	out = append(out, '.')
-	out = strconv.AppendUint(out, uint64(src[0]%40), 10)
+	if v < 80 {
+		out = strconv.AppendUint(out, uint64(v/40), 10)
+		out = append(out, '.')
+		out = strconv.AppendUint(out, uint64(v%40), 10)
+	} else {
+		out = append(out, '2', '.')
+		out = strconv.AppendUint(out, uint64(v-80), 10)
+	}
 
-	var v uint32
-	var err error
-	for offset := 1; offset < len(src); {
+	for offset < len(src) {
 		out = append(out, '.')
 		v, offset, err = parseBase128Uint32(src, offset)
 		if err != nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -58,6 +58,22 @@ func TestParseObjectIdentifier(t *testing.T) {
 			data: []byte{40}, // 1*40 + 0 = 40
 			want: ".1.0",
 		},
+		// Multi-byte first sub-identifier (X.690 8.19.5)
+		{
+			name: "joint-iso-itu-t 2.999 (X.690 example)",
+			data: []byte{0x88, 0x37, 0x03}, // first sub-id 1079 = 2*40+999, then arc 3
+			want: ".2.999.3",
+		},
+		{
+			name: "joint-iso-itu-t 2.40",
+			data: []byte{0x81, 0x00}, // first sub-id 128 = 2*40+48
+			want: ".2.48",
+		},
+		{
+			name: "joint-iso-itu-t 2.100 (stdlib test vector)",
+			data: []byte{0x81, 0x34, 0x03}, // first sub-id 180 = 2*40+100, then arc 3
+			want: ".2.100.3",
+		},
 		// Standard OIDs
 		{
 			name: "sysDescr (1.3.6.1.2.1.1.1)",
@@ -112,6 +128,12 @@ func TestParseObjectIdentifier(t *testing.T) {
 			data:    []byte{43, 0x90, 0x80, 0x80, 0x80, 0x00},
 			want:    "",
 			wantErr: ErrBase128IntegerTooLarge,
+		},
+		{
+			name:    "truncated first sub-id",
+			data:    []byte{0x80}, // continuation byte as only byte
+			want:    "",
+			wantErr: ErrBase128IntegerTruncated,
 		},
 		{
 			name:    "truncated multi-byte sub-id",


### PR DESCRIPTION
This PR addresses a minor correctness issue in oid decoding. It's a bit academic as it would only impact oids in ranges that AFAIK don't exist, but the current implementation is technically incorrect. The encoding side also needs fixing, but will do as a second PR.

`parseObjectIdentifier` reads the first content byte of an OID as a raw byte value (`src[0]/40`, `src[0]%40`) instead of decoding it with `parseBase128Uint32`. The first sub-identifier uses standard base-128 encoding like all others (X.690 8.19.2), so this produces wrong results when `arc1*40 + arc2 > 127`.

This code appears to have been copied from an early version of Go's `encoding/asn1` which had the same bug. The stdlib has since been fixed to use `parseBase128Int` for the first sub-identifier - this change follows the same approach.

Example: OID `2.999.3` (the example from X.690 8.19.5) encodes as `88 37 03`. Without this fix, gosnmp decodes it as `.3.16.55`. With this fix it correctly returns `.2.999.3`.

The arc decomposition now matches the stdlib pattern:
- `v < 80`: `arc1 = v/40`, `arc2 = v%40`
- `v >= 80`: `arc1 = 2`, `arc2 = v-80`

Test cases include tests from the stdlib test suite and the X.690 spec.

Equivalent code in net-snmp for reference can be found at https://github.com/net-snmp/net-snmp/blob/e8a9e5232842b793c6ae51663f6bd3ebfac3fdf5/snmplib/asn1.c#L1535

Here's a pr link for the change in the stdlib that has some discussion: https://codereview.appspot.com/10140046
