### PR TITLE
fix: decode zero-length encoded OID as .0.0 like net-snmp

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -686,7 +686,8 @@ func parseLength(bytes []byte) (int, int, error) {
 // that are assigned in a hierarchy.
 func parseObjectIdentifier(src []byte) (string, error) {
 	if len(src) == 0 {
-		return "", ErrInvalidOidLength
+		// net-snmp decodes a zero-length encoded OID as ".0.0"
+		return ".0.0", nil
 	}
 
 	// Worst-case: first byte expands to 5 chars (".2.39"), rest to 4 chars (".127")

--- a/helper_test.go
+++ b/helper_test.go
@@ -100,13 +100,12 @@ func TestParseObjectIdentifier(t *testing.T) {
 			data: []byte{43, 6, 1, 2, 1, 31, 1, 1, 1, 10, 0x8F, 0xFF, 0xFF, 0xFF, 0x7F},
 			want: ".1.3.6.1.2.1.31.1.1.1.10.4294967295",
 		},
-		// Error cases
 		{
-			name:    "empty input",
-			data:    []byte{},
-			want:    "",
-			wantErr: ErrInvalidOidLength,
+			name: "zero-length encoded OID",
+			data: []byte{},
+			want: ".0.0",
 		},
+		// Error cases
 		{
 			name:    "overflow sub-id (4294967296)",
 			data:    []byte{43, 0x90, 0x80, 0x80, 0x80, 0x00},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2423,7 +2423,8 @@ func TestUnmarshalVBL(t *testing.T) {
 		{"truncated_base128_OID", buildVBL(buildSequence(append(buildTLVHeader(0x06, 3), 0x2b, 0x86, 0x86))), true, 0, nil},
 		{"overflow_base128_OID", buildVBL(buildSequence(append(buildTLVHeader(0x06, 7), 0x2b, 0x8F, 0x8F, 0x8F, 0x8F, 0x8F, 0x01))), true, 0, nil},
 		{"OID_length_exceeds_data", buildVBL(buildSequence(append(buildTLVHeader(0x06, 10), 0x2b, 0x06, 0x01))), true, 0, nil},
-		{"zero_length_OID", buildVBL(buildSequence(append([]byte{0x06, 0x00}, 0x04, 0x04, 0x74, 0x65, 0x73, 0x74))), true, 0, nil},
+		{"zero_length_OID", buildVBL(buildSequence(append([]byte{0x06, 0x00}, 0x04, 0x04, 0x74, 0x65, 0x73, 0x74))), false, 1,
+			[]wantPDU{{".0.0", OctetString, []byte("test")}}},
 
 		// Trailing bytes inside varbind body (value TLV doesn't fill SEQUENCE)
 		{"trailing_junk_after_Null", buildVBL(rawVB(0x01, []byte{0x05, 0x00, 0xFF})), true, 1,


### PR DESCRIPTION
`parseObjectIdentifier` rejected a zero-length encoded OBJECT IDENTIFIER with `invalid OID length`, which made gosnmp (and Telegraf's snmp input) fail whole bulk walks on responses that net-snmp/snmpwalk parse fine. It now returns `.0.0` for an empty encoding, matching net-snmp.

Closes: #564.