### PR TITLE
Update linting

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,4 +31,4 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           args: --verbose
-          version: v2.11.3
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,8 @@ linters:
     - unparam
     - whitespace
   settings:
+    goconst:
+      ignore-tests: true
     gocritic:
       disabled-checks:
         - exitAfterDefer

--- a/examples/linux_vrf/main.go
+++ b/examples/linux_vrf/main.go
@@ -29,7 +29,7 @@ func main() {
 		// https://www.kernel.org/doc/Documentation/networking/vrf.txt
 		Control: func(_, _ string, c syscall.RawConn) error {
 			return c.Control(func(fd uintptr) {
-				_ = syscall.BindToDevice(int(fd), "VRF1") //nolint:gosec
+				_ = syscall.BindToDevice(int(fd), "VRF1")
 			})
 		},
 		// Specify an IP address within the VRF

--- a/test_utils.go
+++ b/test_utils.go
@@ -10,6 +10,9 @@ import (
 	"time"
 )
 
+// newTestGoSNMP is only used in tests.
+//
+//nolint:unused
 func newTestGoSNMP() *GoSNMP {
 	return &GoSNMP{
 		Port:               161,
@@ -24,6 +27,9 @@ func newTestGoSNMP() *GoSNMP {
 	}
 }
 
+// newTestGoSNMPv3 is only used in tests.
+//
+//nolint:unused
 func newTestGoSNMPv3(msgFlags SnmpV3MsgFlags, sp SnmpV3SecurityParameters) *GoSNMP {
 	gs := newTestGoSNMP()
 	gs.Version = Version3


### PR DESCRIPTION
Update golangci-lint to the latest release.
* Cleanup linting issues
* Don't test for const strings in tests.