### PR TITLE
fix: validate msgAuthenticationParameters length in SNMPv3 USM unmarshal

### DIFF
--- a/v3_usm.go
+++ b/v3_usm.go
@@ -1056,6 +1056,13 @@ func (sp *UsmSecurityParameters) unmarshal(flags SnmpV3MsgFlags, packet []byte, 
 		if sp.AuthenticationProtocol <= NoAuth {
 			return 0, errors.New("error parsing SNMPv3 User Security Model: authentication parameters are not configured to parse incoming authenticated message")
 		}
+		// The wire field must be exactly the configured protocol's MAC size before
+		// it is blanked with the fixed-length placeholder below; a shorter field
+		// slices past the packet end (remote panic) and any mismatch mis-blanks the
+		// following msgPrivacyParameters field.
+		if expected := len(macVarbinds[sp.AuthenticationProtocol]); count != expected {
+			return 0, fmt.Errorf("error parsing SNMPv3 User Security Model: msgAuthenticationParameters length %d does not match configured auth protocol (expected %d)", count, expected)
+		}
 		copy(packet[cursor+2:cursor+len(macVarbinds[sp.AuthenticationProtocol])], macVarbinds[sp.AuthenticationProtocol][2:])
 	}
 	cursor += count

--- a/v3_usm_test.go
+++ b/v3_usm_test.go
@@ -320,6 +320,144 @@ func TestUnmarshalTruncatedUSMSequence(t *testing.T) {
 	}
 }
 
+// buildUSMAuthParams assembles a minimal USM securityParameters SEQUENCE with an
+// empty engineID/username and the given msgAuthenticationParameters and trailing
+// msgPrivacyParameters fields, as they appear on the wire.
+func buildUSMAuthParams(authParams, privacy []byte) []byte {
+	body := []byte{
+		0x04, 0x00, // msgAuthoritativeEngineID ""
+		0x02, 0x01, 0x00, // msgAuthoritativeEngineBoots 0
+		0x02, 0x01, 0x00, // msgAuthoritativeEngineTime 0
+		0x04, 0x00, // msgUserName ""
+	}
+	body = append(body, authParams...)
+	body = append(body, privacy...)
+	return append([]byte{0x30, byte(len(body))}, body...) //nolint:gosec
+}
+
+// octetString wraps value as a BER OCTET STRING (tag 0x04).
+func octetString(value []byte) []byte {
+	return append([]byte{0x04, byte(len(value))}, value...) //nolint:gosec
+}
+
+// TestUnmarshalAuthParamsLengthMismatch covers the msgAuthenticationParameters
+// blanking copy. unmarshal rewrites the field using the locally configured MAC
+// length (macVarbinds[AuthenticationProtocol]); a wire field whose length differs
+// from that must be rejected before the copy, otherwise a short field panics with
+// a slice-bounds error (remote unauthenticated DoS) or silently overwrites the
+// following msgPrivacyParameters field. Sibling of TestUnmarshalTruncatedUSMSequence.
+func TestUnmarshalAuthParamsLengthMismatch(t *testing.T) {
+	sp := &UsmSecurityParameters{
+		Logger: NewLogger(log.New(io.Discard, "", 0)),
+	}
+
+	privacy := octetString([]byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88})
+
+	tests := []struct {
+		name       string
+		proto      SnmpV3AuthProtocol
+		authParams []byte
+		privacy    []byte
+		wantErr    bool
+	}{
+		{
+			// Short field with no trailing bytes: the fixed-length copy reads
+			// past the end of the packet buffer and panics without the guard.
+			name:       "SHA short field at packet end",
+			proto:      SHA,
+			authParams: octetString([]byte{0xAA, 0xBB}),
+			wantErr:    true,
+		},
+		{
+			// Short field followed by msgPrivacyParameters: no panic, but the
+			// copy silently zeroes the trailing privacy field without the guard.
+			name:       "SHA short field corrupts trailing privacy",
+			proto:      SHA,
+			authParams: octetString([]byte{0xAA, 0xBB}),
+			privacy:    privacy,
+			wantErr:    true,
+		},
+		{
+			// Over-declared field (longer than the MAC) is equally illegal per
+			// USM and mis-blanks; equality, not a lower bound, must reject it.
+			name:       "SHA over-declared field",
+			proto:      SHA,
+			authParams: octetString(make([]byte, 20)),
+			privacy:    privacy,
+			wantErr:    true,
+		},
+		{
+			// A SHA-sized (12-byte) field is the wrong length for SHA256 (24).
+			name:       "SHA-sized field wrong for SHA256",
+			proto:      SHA256,
+			authParams: octetString(make([]byte, 12)),
+			privacy:    privacy,
+			wantErr:    true,
+		},
+		{
+			name:       "MD5 correct length",
+			proto:      MD5,
+			authParams: octetString(make([]byte, 12)),
+			privacy:    octetString(nil),
+		},
+		{
+			name:       "SHA correct length",
+			proto:      SHA,
+			authParams: octetString(make([]byte, 12)),
+			privacy:    octetString(nil),
+		},
+		{
+			name:       "SHA224 correct length",
+			proto:      SHA224,
+			authParams: octetString(make([]byte, 16)),
+			privacy:    octetString(nil),
+		},
+		{
+			name:       "SHA256 correct length",
+			proto:      SHA256,
+			authParams: octetString(make([]byte, 24)),
+			privacy:    octetString(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp.AuthenticationProtocol = tt.proto
+			packet := buildUSMAuthParams(tt.authParams, tt.privacy)
+			before := append([]byte(nil), packet...)
+
+			require.NotPanics(t, func() {
+				_, err := sp.unmarshal(AuthNoPriv, packet, 0)
+				if tt.wantErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+
+			// A rejected packet must be left untouched: the blanking copy must
+			// not run before the length check.
+			if tt.wantErr && len(tt.privacy) > 0 {
+				require.Equal(t, before, packet, "packet buffer modified despite rejection")
+			}
+		})
+	}
+}
+
+// TestUnmarshalAuthParamsMisconfigured preserves the pre-existing behaviour: an
+// authenticated message received while no auth protocol is configured is rejected.
+func TestUnmarshalAuthParamsMisconfigured(t *testing.T) {
+	sp := &UsmSecurityParameters{
+		AuthenticationProtocol: NoAuth,
+		Logger:                 NewLogger(log.New(io.Discard, "", 0)),
+	}
+	packet := buildUSMAuthParams(octetString(make([]byte, 12)), octetString(nil))
+	require.NotPanics(t, func() {
+		_, err := sp.unmarshal(AuthNoPriv, packet, 0)
+		require.Error(t, err)
+	})
+}
+
 func BenchmarkSingleHash(b *testing.B) {
 	SetPwdCache()
 


### PR DESCRIPTION
`UsmSecurityParameters.unmarshal` blanks the `msgAuthenticationParameters` field with a fixed-length placeholder sized from the locally configured auth protocol (`macVarbinds[AuthenticationProtocol]`), but never checks the wire field's actual length. A field shorter than the configured MAC makes the copy at `v3_usm.go:1059` slice past the end of the packet buffer and panic (`slice bounds out of range`); a longer packet is silently corrupted where the copy overwrites the following `msgPrivacyParameters` field.

This runs during header parsing, before `testAuthentication`, so a remote unauthenticated sender can crash any SNMPv3-auth manager or `TrapListener` with a single crafted packet — the same exposure as #577 (`9343e6e`), one field earlier.

Fix: reject the field unless its length equals the configured protocol's MAC size, before the blanking copy. Added a table-driven test covering the short (panic), over-declared, wrong-protocol, and correct-length cases for MD5/SHA/SHA224/SHA256.

I also checked the send-path copy at `v3_usm.go:784` (`authenticate`): the `idx < 0` guard plus `bytes.Index` locating the full placeholder keep that copy in-bounds, so it needs no change.