### PR TITLE
Handel malformed data in IPAdress field.

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -139,6 +139,7 @@ func (x *GoSNMP) decodeValue(data []byte, retVal *variable) error {
 		ipLen := length - cursor
 		switch ipLen {
 		case 0: // real life, buggy devices returning bad data
+		case 8:
 			retVal.Value = nil
 			return nil
 		case 4: // IPv4

--- a/helper_test.go
+++ b/helper_test.go
@@ -646,6 +646,12 @@ func TestIPAddressDecodeValue(t *testing.T) {
 			data:     []byte{0x40, 0x00},
 			wantNull: true,
 		},
+		{
+			name:     "8 byte payload treated as null",
+			data:     []byte{0x40, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			wantNull: true,
+			wantErr:  false,
+		},
 		// Error cases
 		{
 			name:    "truncated IPv4 data",
@@ -658,8 +664,8 @@ func TestIPAddressDecodeValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "invalid length (not 0, 4, or 16)",
-			data:    []byte{0x40, 0x08, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			name:    "invalid length (not 0, 4, 8, or 16)",
+			data:    []byte{0x40, 0x09, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09},
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
WatchGuard devices have been identified to populate IP address fields with incorrect data, specifically payloads that are consistently 8 bytes in length. Whenever a valid IP address is unavailable. 

This results in the following error message:
```
error in unmarshalResponse: error decoding value: got ipaddress len 8, expected 4 or 16
``` 

Since standard implementations like net-snmp do not encounter this error, it is nice to implement a safeguard within gosnmp to handle these malformed fields gracefully. 

Similar issues have been reported here: https://github.com/prometheus/snmp_exporter/discussions/1357