### PR TITLE
Migrate remaining CI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,65 +4,25 @@ version: 2.1
 executors:
   golang:
     docker:
-    - image: cimg/go:1.26
+      - image: busybox
 
 jobs:
-  test:
-    parameters:
-      goarch:
-        type: string
-      goversion:
-        type: string
-    docker:
-      - image: cimg/go:<< parameters.goversion >>
-    environment:
-      GOARCH: << parameters.goarch >>
-      GOSNMP_TARGET: "127.0.0.1"
-      GOSNMP_PORT: "161"
-      GOSNMP_TARGET_IPV4: "127.0.0.1"
-      GOSNMP_PORT_IPV4: "161"
-      GOSNMP_TARGET_IPV6: "::1"
-      GOSNMP_PORT_IPV6: "161"
+  noopjob:
+    executor: golang
 
     steps:
-    - checkout
-    - run: sudo apt-get update
-    - run: sudo apt-get -y install snmpd
-    - run: sudo ./snmp_users.sh
-    - run: sudo sed -i -e 's/^agentaddress.*$/agentaddress 127.0.0.1/' /etc/snmp/snmpd.conf
-    - run: sudo service snmpd restart
-    - run: go test -v -tags helper
-    - run: go test -v -tags marshal
-    - run: go test -v -tags misc
-    - run: go test -v -tags api
-    - run: go test -v -tags end2end
-    # - run: go test -v -tags trap
-    - run: |
-       if [[ "${GOARCH}" == "amd64" ]]; then
-         go test -v -tags all -race
-       else
-         echo "Not running -race"
-       fi
-    - run: make -C netsnmp test
-    - run: |
-       if [[ "${GOARCH}" == "amd64" ]]; then
-         sudo apt-get -y install libsnmp-dev
-         make -C netsnmp test_netsnmp
-       else
-         echo "Not running net-snmp tests"
-       fi
+      - run:
+          command: "true"
 
 workflows:
   version: 2
-  test:
+  noop:
     jobs:
-    - test:
-        matrix:
-          parameters:
-            goarch:
-            - "amd64"
-            - "386"
-            goversion:
-            - "1.24"
-            - "1.25"
-            - "1.26"
+      - noopjob
+    triggers:
+      - schedule:
+          cron: "0 0 30 2 *"
+          filters:
+            branches:
+              only:
+                - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -45,8 +49,69 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 1.27.x
       - run: go test -fuzztime 60s -v -tags marshal -fuzz '^FuzzUnmarshal$'
+
+  net-snmp-test:
+    name: Test net-snmp
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 1.27.x
+      - run: sudo apt-get -y install libsnmp-dev
+      - run: make -C netsnmp test_netsnmp
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go_arch:
+          - "amd64"
+          - "386"
+        go_version:
+          - "1.24.x"
+          - "1.25.x"
+          - "1.26.x"
+          - "1.27.x"
+    env:
+      GOARCH: ${{ matrix.go_arch }}
+      GOSNMP_TARGET: "127.0.0.1"
+      GOSNMP_PORT: "161"
+      GOSNMP_TARGET_IPV4: "127.0.0.1"
+      GOSNMP_PORT_IPV4: "161"
+      GOSNMP_TARGET_IPV6: "::1"
+      GOSNMP_PORT_IPV6: "161"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ matrix.go_version }}
+      - run: sudo apt-get update
+      - run: sudo apt-get -y install snmpd
+      - run: sudo ./snmp_users.sh
+      - run: sudo sed -i -e 's/^agentaddress.*$/agentaddress 127.0.0.1/' /etc/snmp/snmpd.conf
+      - run: sudo service snmpd restart
+      - run: go test -v -tags helper
+      - run: go test -v -tags marshal
+      - run: go test -v -tags misc
+      - run: go test -v -tags api
+      - run: go test -v -tags end2end
+      - run: make -C netsnmp test
+      - if: matrix.go_arch == 'amd64'
+        run: go test -v -tags all -race


### PR DESCRIPTION
Migrate the remaining CI workflows to GitHub Actions.
* Add noop CircleCI config.
* Split net-snmp test into a separate job.
* Set persist-credentials to false for improved checkout security.